### PR TITLE
refactor: consolidate theme system to standard single-token pattern

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -24,6 +24,15 @@ const geistMono = localFont({
 
 const validLocales = ['en', 'es'] as const;
 
+// Inline script to set the theme class synchronously before first paint, preventing flash
+const themeScript = `(function(){
+  try {
+    var t = localStorage.getItem('theme');
+    if (!t) { t = window.matchMedia('(prefers-color-scheme:dark)').matches ? 'dark' : 'light'; }
+    document.documentElement.classList.add(t);
+  } catch(e) {}
+})();`;
+
 export function generateStaticParams() {
   return validLocales.map(locale => ({ locale }));
 }
@@ -123,6 +132,7 @@ export default async function RootLayout(props: { children: React.ReactNode; par
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
+        <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <link rel="manifest" href="/manifest.webmanifest" />
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -13,35 +13,22 @@ body {
 }
 @layer base {
   :root {
-    --background-light: 73 17% 96%;
-    --foreground-light: 225 27% 33%%;
-    --primary-light: 218 59% 37%;
-    --primary-foreground-light: 210 40% 98%;
-
-    --background-dark: 217 39% 12%;
-    --foreground-dark: 205 76% 94%;
-
-    --primary-dark: 190 84% 77%;
-    --primary-foreground-dark: 190 34.14% 59.93%;
-
-    --secondary-light: 28 100% 31%;
-    --secondary-dark: 46 100% 72%;
-
-    --muted-light: 190 30% 84%;
-    --muted-dark: 208 44% 20%;
+    --background: 73 17% 96%;
+    --foreground: 225 27% 33%;
+    --primary: 218 59% 37%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 28 100% 31%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 190 30% 84%;
+    --muted-foreground: 215.4 16.3% 46.9%;
+    --accent: 133 42% 40%;
+    --accent-foreground: 222.2 47.4% 11.2%;
 
     --card: 0 0% 100%;
     --card-foreground: 222.2 84% 4.9%;
 
     --popover: 0 0% 100%;
     --popover-foreground: 222.2 84% 4.9%;
-
-    --muted: 210 40% 96%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-
-    --accent: 133 42% 40%;
-    --accent-dark: 104.05 74% 75%;
-    --accent-foreground: 222.2 47.4% 11.2%;
 
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%;
@@ -54,26 +41,22 @@ body {
   }
 
   .dark {
-    --background: var(--background-dark);
-    --foreground: var(--foreground-dark);
-    --primary: var(--primary-dark);
-    --primary-foreground: var(--primary-foreground-dark);
-    --secondary: var(--secondary-dark);
+    --background: 217 39% 12%;
+    --foreground: 205 76% 94%;
+    --primary: 190 84% 77%;
+    --primary-foreground: 190 34.14% 59.93%;
+    --secondary: 46 100% 72%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 208 44% 20%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 104.05 74% 75%;
+    --accent-foreground: 210 40% 98%;
 
     --card: 222.2 84% 4.9%;
     --card-foreground: 210 40% 98%;
 
     --popover: 222.2 84% 4.9%;
     --popover-foreground: 210 40% 98%;
-
-    /* --secondary: 217.2 32.6% 17.5%; */
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: var(--muted-dark);
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: var(--accent-foreground-dark);
-    --accent-foreground: 210 40% 98%;
 
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
@@ -91,9 +74,6 @@ body {
   body {
     @apply bg-background text-foreground;
     transition: background-color 0.3s ease, color 0.3s ease;
-    .dark & {
-      @apply bg-background-dark text-foreground-dark;
-    }
   }
 
   .underline-heading {
@@ -106,13 +86,13 @@ body {
     position: absolute;
     bottom: -4px; /* Adjust this value based on spacing preference */
     left: 0;
-    @apply border-t border border-primary dark:border-primary-dark border-dashed w-2/5;
+    @apply border-t border border-primary border-dashed w-2/5;
   }
 }
 
 @layer components {
   .toast-success {
-    @apply bg-accent-dark text-background-dark border-transparent;
+    @apply bg-accent text-background border-transparent;
   }
 
   .toast-error {

--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -23,31 +23,31 @@ const AboutMe = () => {
             fetchPriority="high"
             sizes="200px"
           />
-          <small className="text-xl mb-1 font-medium text-secondary dark:text-secondary-dark block">{t('greeting.hello')}</small>
-          <h1 className="text-6xl sm:text-7xl font-bold text-primary dark:text-primary-dark mb-2">William Craig!</h1>
+          <small className="text-xl mb-1 font-medium text-secondary block">{t('greeting.hello')}</small>
+          <h1 className="text-6xl sm:text-7xl font-bold text-primary mb-2">William Craig!</h1>
           <h2 className="text-3xl sm:text-4xl mb-2">{t('greeting.role')}</h2>
-          <h2 className="text-2xl mb-2 text-secondary dark:text-secondary-dark">Fullstack, Frontend, UX</h2>
-          <p className=" text-primary dark:text-primary-dark text-2xl font-medium">{t('greeting.title')}</p>
+          <h2 className="text-2xl mb-2 text-secondary">Fullstack, Frontend, UX</h2>
+          <p className=" text-primary text-2xl font-medium">{t('greeting.title')}</p>
         </section>
 
-        <hr className="border-t-1 border-primary dark:border-primary-dark border-dashed mt-14 mb-14 w-5/6" />
+        <hr className="border-t-1 border-primary border-dashed mt-14 mb-14 w-5/6" />
 
         {/* About me section */}
-        <h2 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-3xl underline-heading">{t('title')}</h2>
+        <h2 className="text-3xl font-extrabold text-primary sm:text-3xl underline-heading">{t('title')}</h2>
         <p className="mt-4 text-lg font-medium  ">{t('intro')}</p>
 
         {/* What I do section */}
         <section className="mt-14 lg:w-5/6">
-          <h3 className="text-2xl font-bold text-primary dark:text-primary-dark underline-heading">{t('whatIDo')}</h3>
+          <h3 className="text-2xl font-bold text-primary underline-heading">{t('whatIDo')}</h3>
           <ul className="mt-4 space-y-0">
             {['fullStack', 'design', 'performance', 'problemSolving'].map((item, index) => (
               <li key={index} className="flex items-center">
-                <span className="flex-shrink-0 h-8 w-8 mr-3 text-secondary dark:text-secondary-dark" aria-hidden="true">
+                <span className="flex-shrink-0 h-8 w-8 mr-3 text-secondary" aria-hidden="true">
                   <Icon icon={whatIDoIcons[index]} width="28" height="28" />
                 </span>
                 <p className="text-lg font-light">
                   {t.rich(`skills.${item}`, {
-                    em: chunks => <em className="text-secondary dark:text-secondary-dark">{chunks}</em>,
+                    em: chunks => <em className="text-secondary">{chunks}</em>,
                   })}
                 </p>
               </li>
@@ -60,11 +60,11 @@ const AboutMe = () => {
 
         {/* Fun Facts section */}
         <section className="mt-14">
-          <h3 className="text-2xl font-bold mb-4 text-primary dark:text-primary-dark underline-heading">{t('funFacts.title')}</h3>
+          <h3 className="text-2xl font-bold mb-4 text-primary underline-heading">{t('funFacts.title')}</h3>
           <ul className="mt-0 space-y-0">
             {['languages', 'power', 'music', 'hobby'].map((fact, index) => (
               <li key={index} className="flex items-center">
-                <span className="flex-shrink-0 h-8 w-8 mr-3 text-secondary dark:text-secondary-dark" aria-hidden="true">
+                <span className="flex-shrink-0 h-8 w-8 mr-3 text-secondary" aria-hidden="true">
                   <Icon icon={funFactIcons[index]} width="28" height="28" />
                 </span>
                 <p className="text-base text-gray-700 dark:text-gray-300">{t(`funFacts.${fact}`)}</p>
@@ -75,7 +75,7 @@ const AboutMe = () => {
 
         {/* Connect section */}
         <section className="mt-14 lg:mt-0 ">
-          <h3 className="text-2xl font-bold mb-4 text-primary dark:text-primary-dark underline-heading block lg:hidden">{t('connect')}</h3>
+          <h3 className="text-2xl font-bold mb-4 text-primary underline-heading block lg:hidden">{t('connect')}</h3>
           <div
             className="mt-1 flex bottom-4  static flex-row  space-x-4
           lg:fixed lg:space-y-4 lg:space-x-0 lg:flex-col lg:bottom-14 lg:mb-4 lg:left-4"
@@ -87,7 +87,7 @@ const AboutMe = () => {
               aria-label="Visit William Craig's GitHub profile (opens in new tab)"
             >
               <span className="sr-only">GitHub</span>
-              <Icon icon="mdi:github" width="28" height="28" className="text-accent dark:text-accent-dark dark:hover:text-secondary-dark" />
+              <Icon icon="mdi:github" width="28" height="28" className="text-accent hover:text-secondary" />
             </a>
             <a
               href="https://linkedin.com/in/willcraigz"
@@ -100,7 +100,7 @@ const AboutMe = () => {
                 icon="mdi:linkedin"
                 width="28"
                 height="28"
-                className="text-accent dark:text-accent-dark dark:hover:text-secondary-dark"
+                className="text-accent hover:text-secondary"
               />
             </a>
             <a
@@ -114,7 +114,7 @@ const AboutMe = () => {
                 icon="mdi:behance"
                 width="28"
                 height="28"
-                className="text-accent dark:text-accent-dark dark:hover:text-secondary-dark"
+                className="text-accent hover:text-secondary"
               />
             </a>
             <a
@@ -128,7 +128,7 @@ const AboutMe = () => {
                 icon="mdi:instagram"
                 width="28"
                 height="28"
-                className="text-accent dark:text-accent-dark dark:hover:text-secondary-dark"
+                className="text-accent hover:text-secondary"
               />
             </a>
           </div>

--- a/components/ArticleLayout.tsx
+++ b/components/ArticleLayout.tsx
@@ -23,7 +23,7 @@ const ArticleLayout: React.FC<ArticleLayoutProps> = ({ post }) => {
   const url = post.language === 'en' ? `${baseUrl}/blog/${post.slug}` : `${baseUrl}/${post.language}/blog/${post.slug}`;
   const imageUrl = post.image ? `${baseUrl}${post.image}` : `${baseUrl}/images/profile.png`;
   const excerpt = post.excerpt || (post.content ? post.content.substring(0, 160).replace(/[#*`]/g, '').trim() + '...' : 'Blog post by William Craig');
-  
+
   // Parse date for structured data
   const publishedDate = post.date ? new Date(post.date).toISOString() : new Date().toISOString();
 
@@ -58,12 +58,12 @@ const ArticleLayout: React.FC<ArticleLayoutProps> = ({ post }) => {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(articleStructuredData) }}
       />
       <header className="relative h-[60vh] mb-8">
-        <Image 
-          src={post.image || '/images/placeholder-image.jpg'} 
-          alt={`Featured image for blog post: ${post.title}`} 
-          fill 
-          className="object-cover rounded-md" 
-          priority 
+        <Image
+          src={post.image || '/images/placeholder-image.jpg'}
+          alt={`Featured image for blog post: ${post.title}`}
+          fill
+          className="object-cover rounded-md"
+          priority
         />
         <div className="py-8 mx-auto max-w-screen-lg container">
           <div className="text-sm uppercase tracking-wide">{post.category}</div>
@@ -78,8 +78,8 @@ const ArticleLayout: React.FC<ArticleLayoutProps> = ({ post }) => {
                 <AvatarFallback>{post.author}</AvatarFallback>
               </Avatar>
               <div>
-                <div className="font-semibold text-accent dark:text-accent-dark">{post?.author}</div>
-                <div className="text-sm text-secondary dark:text-secondary-dark">
+                <div className="font-semibold text-accent">{post?.author}</div>
+                <div className="text-sm text-secondary">
                   {post.date} · {post.readTime}
                 </div>
               </div>
@@ -89,20 +89,20 @@ const ArticleLayout: React.FC<ArticleLayoutProps> = ({ post }) => {
               <ShareButton title={post.title} url={`${process.env.NEXT_PUBLIC_BASE_URL}/blog/${post.slug}`} />
             </div>
           </div>
-          <h1 className="text-4xl font-bold text-primary dark:text-primary-dark mb-12 mt-6 underline-heading">{post.title}</h1>
-          <div className="prose dark:prose-invert max-w-none prose-headings:font-bold prose-headings:text-foreground dark:prose-headings:text-primary-dark prose-headings:mb-2 prose-p:text-foreground dark:prose-p:text-foreground-dark prose-a:text-secondary dark:prose-a:text-secondary-dark prose-ul:list-disc prose-ol:list-decimal prose-li:m-0 prose-pre:bg-transparent prose-pre:p-0 prose-code:text-current mdx-content">
+          <h1 className="text-4xl font-bold text-primary mb-12 mt-6 underline-heading">{post.title}</h1>
+          <div className="prose dark:prose-invert max-w-none prose-headings:font-bold prose-headings:text-foreground prose-headings:mb-2 prose-p:text-foreground prose-a:text-secondary prose-ul:list-disc prose-ol:list-decimal prose-li:m-0 prose-pre:bg-transparent prose-pre:p-0 prose-code:text-current mdx-content">
             <MDXRemote source={post.content} components={components} />
           </div>
         </section>
       </main>
-      <hr className="border-t-1 border-primary dark:border-primary-dark border-dashed mt-14 mb-14" />
+      <hr className="border-t-1 border-primary border-dashed mt-14 mb-14" />
 
       {post.tags && post.tags.length > 0 && (
         <section className="container mx-auto max-w-screen-lg px-4 mt-0">
-          <h2 className="text-xl text-primary dark:text-primary-dark font-semibold mb-2 ">Tags</h2>
+          <h2 className="text-xl text-primary font-semibold mb-2 ">Tags</h2>
           <ul className="flex flex-wrap gap-2">
             {post.tags.map((tag, index) => (
-              <li key={index} className="text-xs bg-muted dark:bg-muted-dark px-2 py-1 rounded text-primary dark:text-primary-dark">
+              <li key={index} className="text-xs bg-muted px-2 py-1 rounded text-primary">
                 {tag}
               </li>
             ))}

--- a/components/BlogList.tsx
+++ b/components/BlogList.tsx
@@ -20,20 +20,20 @@ export default function BlogList({ posts, locale, t }: BlogListProps) {
   return (
     <Layout>
       <div className="pt-14 mt-12 sm:max-w-4xl mx-auto">
-        <h1 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-3xl underline-heading mb-4">{t('title')}</h1>
-        <p className="text-secondary dark:text-secondary-dark text-lg font-medium mb-4">{t('description')}</p>
+        <h1 className="text-3xl font-extrabold text-primary sm:text-3xl underline-heading mb-4">{t('title')}</h1>
+        <p className="text-secondary text-lg font-medium mb-4">{t('description')}</p>
 
         {featuredPost && (
-          <article className="my-12 grid md:grid-cols-2 gap-8 items-center rounded-md pl-7 border border-muted dark:border-muted-dark shadow-md shadow-black:20 dark:shadow-black:80 p-7 md:p-0 md:pl-7">
+          <article className="my-12 grid md:grid-cols-2 gap-8 items-center rounded-md pl-7 border border-muted shadow-md shadow-black:20 dark:shadow-black:80 p-7 md:p-0 md:pl-7">
             <header>
               <Link href={`/${locale}/blog/${featuredPost.slug}`}>
-                <h2 className="text-4xl text-primary dark:text-primary-dark font-bold mb-4 ">{featuredPost.title}</h2>
+                <h2 className="text-4xl text-primary font-bold mb-4 ">{featuredPost.title}</h2>
               </Link>
 
               <p className="text-gray-600 dark:text-gray-300 mb-4">{featuredPost.excerpt}</p>
               <Link
                 href={`/${locale}/blog/${featuredPost.slug}`}
-                className="underline text-secondary dark:text-secondary-dark hover:no-underline hover:text-primary dark:hover:text-primary-dark"
+                className="underline text-secondary hover:no-underline hover:text-primary"
               >
                 {t('readMore')}
               </Link>
@@ -57,7 +57,7 @@ export default function BlogList({ posts, locale, t }: BlogListProps) {
           {otherPosts.map(post => (
             <article
               key={post.slug}
-              className=" border border-muted dark:border-muted-dark shadow-md shadow-black:20 dark:shadow-black:80 rounded-lg overflow-hidden hover:shadow-md transition-shadow duration-300"
+              className=" border border-muted shadow-md shadow-black:20 dark:shadow-black:80 rounded-lg overflow-hidden hover:shadow-md transition-shadow duration-300"
             >
               <Link href={`/${locale}/blog/${post.slug}`} className="group">
                 <figure className="relative h-48">
@@ -72,10 +72,10 @@ export default function BlogList({ posts, locale, t }: BlogListProps) {
                 </figure>
                 <div className="p-4">
                   <header>
-                    <h3 className="text-xl font-semibold mb-2 text-primary dark:text-primary-dark  group-hover:text-secondary dark:group-hover:text-secondary-dark transition-colors duration-300">
+                    <h3 className="text-xl font-semibold mb-2 text-primary group-hover:text-secondary transition-colors duration-300">
                       {post.title}
                     </h3>
-                    <time className="text-sm text-muted-dark dark:text-muted mb-2" dateTime={post.date}>
+                    <time className="text-sm text-muted-foreground mb-2" dateTime={post.date}>
                       {new Date(post.date).toLocaleDateString()}
                     </time>
                   </header>

--- a/components/ClientCodeBlock.tsx
+++ b/components/ClientCodeBlock.tsx
@@ -15,7 +15,7 @@ interface ClientCodeBlockProps {
 const ClientCodeBlock: React.FC<ClientCodeBlockProps> = ({ children, className }) => {
   if (!className) {
     // Render inline code (for single backticks) as a <code> tag
-    return <code className="bg-slate-900 !text-secondary-dark">{children}</code>;
+    return <code className="bg-slate-900 !text-secondary">{children}</code>;
   }
 
   // Render multi-line code blocks (for triple backticks) using Codeblock with syntax highlighting

--- a/components/CompanySelector.tsx
+++ b/components/CompanySelector.tsx
@@ -24,20 +24,18 @@ const CompanySelector: React.FC<CompanySelectorProps> = ({ companies, activeTab,
       {/* Mobile view */}
       <div className="sm:hidden w-full">
         <Select onValueChange={handleSelectChange} value={activeTab.toString()}>
-          <SelectTrigger className="w-full dark:bg-background-dark border-primary border dark:border-primary-dark dark:text-secondary-dark">
+          <SelectTrigger className="w-full bg-background border-primary border">
             <SelectValue placeholder="Select a company" />
           </SelectTrigger>
-          <SelectContent className="bg-background dark:bg-background-dark">
+          <SelectContent className="bg-background">
             {companies.map((company, index) => (
               <SelectItem
                 key={index}
                 value={index.toString()}
-                className=" 
-                hover:text-primary-dark hover:bg-secondary :hover:font-semibold
-                dark:hover:text-primary dark:hover:bg-secondary-dark
-                data-[state=checked]:bg-primary data-[state=checked]:text-foreground-dark
-                dark:data-[state=checked]:bg-primary-dark dark:data-[state=checked]:text-slate-800  
-              cursor-pointer"
+                className="
+                hover:text-primary hover:bg-secondary hover:font-semibold
+                data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground
+                cursor-pointer"
               >
                 {company.title}
               </SelectItem>
@@ -55,8 +53,8 @@ const CompanySelector: React.FC<CompanySelectorProps> = ({ companies, activeTab,
             className={`w-full text-left py-2 px-4 mb-2 font-medium transition border-l-2 border-transparent
               ${
                 activeTab === index
-                  ? 'bg-transparent border-primary border-l-2 dark:border-l-primary-dark dark:text-secondary-dark font-semibold'
-                  : 'hover:bg-transparent hover:text-background dark:hover:text-primary-dark hover:border-secondary hover:dark:border-l-secondary-dark'
+                  ? 'bg-transparent border-primary border-l-2 text-secondary font-semibold'
+                  : 'hover:bg-transparent hover:text-primary hover:border-secondary'
               }`}
           >
             {company.title}

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -73,7 +73,7 @@ const EmailForm: FC = () => {
 
   return (
     <div className="max-w-md mx-auto p-4 flex flex-col content-center place-self-centerpy-14 mt-12 px-4 sm:px-6 lg:px-8">
-      <h2 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-3xl underline-heading mt-4">{t('title')}</h2>
+      <h2 className="text-3xl font-extrabold text-primary sm:text-3xl underline-heading mt-4">{t('title')}</h2>
       <p className="my-8 font-medium ">{t('description')}</p>
       <form onSubmit={handleSubmit} className="space-y-4">
         <Label htmlFor="email">{t('form.email')} </Label>
@@ -104,7 +104,7 @@ const EmailForm: FC = () => {
         <Button
           type="submit"
           disabled={mutation.isPending}
-          className="w-full p-2 rounded bg-accent text-background dark:bg-accent-dark dark:text-background-dark hover:bg-secondary dark:hover:bg-secondary-dark disabled:bg-gray-400"
+          className="w-full p-2 rounded bg-accent text-background hover:bg-secondary disabled:bg-gray-400"
         >
           {mutation.isPending ? t('form.sending') : t('form.send')}
         </Button>

--- a/components/LikeButtonClient.tsx
+++ b/components/LikeButtonClient.tsx
@@ -51,7 +51,7 @@ const LikeButtonClient: React.FC<LikeButtonClientProps> = ({ slug }) => {
     <button
       onClick={handleLike}
       className={`flex items-center space-x-1 duration-300 transition-colors ${
-        liked ? 'text-secondary dark:text-secondary-dark' : 'text-foreground dark:text-foreground-dark'
+        liked ? 'text-secondary' : 'text-foreground'
       }`}
       disabled={liked || likeMutation.isPending}
     >

--- a/components/ProjectShowcase.tsx
+++ b/components/ProjectShowcase.tsx
@@ -22,14 +22,14 @@ const ProjectShowcase = () => {
   return (
     <section>
       <div className="pt-14 mt-12 max-w-2xl mx-auto">
-        <h2 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-3xl underline-heading mb-4">{t('title')}</h2>
-        <p className="text-secondary dark:text-secondary-dark text-lg font-medium mb-4">{t('description')}</p>
+        <h2 className="text-3xl font-extrabold text-primary sm:text-3xl underline-heading mb-4">{t('title')}</h2>
+        <p className="text-secondary text-lg font-medium mb-4">{t('description')}</p>
       </div>
       <div className="pt-4 mt-4 max-w-2xl lg:max-w-5xl mx-auto">
         {apps.map((project: ProjectData) => (
           <Card
             key={project.title}
-            className="w-full bg-transparent border-muted dark:border-muted-dark shadow-md shadow-black:20 dark:shadow-black:80 overflow-hidden mb-14"
+            className="w-full bg-transparent border-muted shadow-md shadow-black:20 dark:shadow-black:80 overflow-hidden mb-14"
           >
             <CardContent className="p-0">
               <div className="flex flex-col lg:flex-row">
@@ -44,13 +44,13 @@ const ProjectShowcase = () => {
                   />
                 </div>
                 <div className="p-6 lg:w-1/2">
-                  <h3 className="text-2xl font-bold text-primary dark:text-primary-dark mb-2">{project.title}</h3>
-                  <p className="text-foreground dark:text-foreground-dark mb-4">{project.description}</p>
+                  <h3 className="text-2xl font-bold text-primary mb-2">{project.title}</h3>
+                  <p className="text-foreground mb-4">{project.description}</p>
                   <div className="flex flex-wrap gap-2 mb-4">
                     {project.tools.map((tool, index) => (
                       <span
                         key={index}
-                        className="text-xs bg-muted dark:bg-muted-dark px-2 py-1 rounded text-primary dark:text-primary-dark"
+                        className="text-xs bg-muted px-2 py-1 rounded text-primary"
                       >
                         {tool}
                       </span>
@@ -62,14 +62,14 @@ const ProjectShowcase = () => {
                         href={project.githubLink}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-primary dark:text-primary-dark hover:text-primary/80 dark:hover:text-primary-dark/80 focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark focus:ring-offset-2 rounded"
+                        className="text-primary hover:text-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
                         aria-label={`View ${project.title} source code on GitHub (opens in new tab)`}
                       >
                         <Icon
                           icon="mdi:github"
                           width="24"
                           height="24"
-                          className="text-primary dark:text-primary-dark hover:text-primary/80 dark:hover:text-primary-dark/80"
+                          className="text-primary hover:text-primary/80"
                           aria-hidden="true"
                         />
                       </a>
@@ -79,7 +79,7 @@ const ProjectShowcase = () => {
                         href={project.liveLink}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-primary dark:text-primary-dark hover:text-primary/80 dark:hover:text-primary-dark/80 focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark focus:ring-offset-2 rounded"
+                        className="text-primary hover:text-primary/80 focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded"
                         aria-label={`Visit ${project.title} live site (opens in new tab)`}
                       >
                         <ExternalLink size={24} aria-hidden="true" />

--- a/components/ShareButton.tsx
+++ b/components/ShareButton.tsx
@@ -32,7 +32,7 @@ const ShareButton: React.FC<ShareButtonProps> = ({ title, url }) => {
   };
 
   return (
-    <Button variant="ghost" className="hover:bg-primary dark:hover:bg-primary-dark" size="sm" onClick={handleShare}>
+    <Button variant="ghost" className="hover:bg-primary" size="sm" onClick={handleShare}>
       <Share2 className="h-5 w-5 mr-2" />
       {t('share')}
     </Button>

--- a/components/TechStack.tsx
+++ b/components/TechStack.tsx
@@ -130,7 +130,7 @@ const TechnologyBadge = ({ tech }: TechnologyBadgeProps) => {
     <div className="relative inline-block" onMouseEnter={() => setIsHovered(true)} onMouseLeave={() => setIsHovered(false)}>
       <Badge
         variant="secondary"
-        className="cursor-pointer transition-all duration-300 px-3 py-1 text-sm bg-muted dark:bg-muted-dark text-muted-foreground/110 dark:text-muted-foreground-dark/70 hover:bg-primary/10 dark:hover:bg-primary-dark/10 hover:text-primary dark:hover:text-primary-dark hover:scale-105"
+        className="cursor-pointer transition-all duration-300 px-3 py-1 text-sm bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary hover:scale-105"
       >
         {tech}
       </Badge>
@@ -138,31 +138,31 @@ const TechnologyBadge = ({ tech }: TechnologyBadgeProps) => {
       {/* Tooltip */}
       {isHovered && techData && (
         <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 z-50 animate-in fade-in-0 slide-in-from-bottom-2 duration-200">
-          <div className="bg-card dark:bg-background-dark border border-muted dark:border-muted-dark rounded-lg shadow-lg p-3 min-w-[200px] max-w-[280px]">
+          <div className="bg-background border border-muted rounded-lg shadow-lg p-3 min-w-[200px] max-w-[280px]">
             {/* Tooltip Arrow */}
-            <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-muted dark:border-t-muted-dark"></div>
+            <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-l-transparent border-r-transparent border-t-muted"></div>
 
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <h4 className="font-semibold text-card-foreground dark:text-foreground-dark text-sm">{tech}</h4>
-                <span className="text-xs text-muted-foreground dark:text-muted-foreground-dark">
+                <h4 className="font-semibold text-foreground text-sm">{tech}</h4>
+                <span className="text-xs text-muted-foreground">
                   {t('since')} {techData.learned}
                 </span>
               </div>
 
               <div>
-                <p className="text-xs font-medium text-card-foreground dark:text-foreground-dark mb-1">{t('usedIn')}</p>
+                <p className="text-xs font-medium text-foreground mb-1">{t('usedIn')}</p>
                 <div className="flex flex-wrap gap-1">
                   {techData.projects.slice(0, 2).map((project) => (
                     <span
                       key={project}
-                      className="text-xs bg-muted/50 dark:bg-muted-dark/50 px-2 py-0.5 rounded text-muted-foreground dark:text-muted-foreground-dark"
+                      className="text-xs bg-muted/50 px-2 py-0.5 rounded text-muted-foreground"
                     >
                       {project}
                     </span>
                   ))}
                   {techData.projects.length > 2 && (
-                    <span className="text-xs text-muted-foreground dark:text-muted-foreground-dark">
+                    <span className="text-xs text-muted-foreground">
                       +{techData.projects.length - 2} {t('more')}
                     </span>
                   )}
@@ -197,7 +197,7 @@ const TechnologyCategory = ({ IconComponent, iconColor, lineColor, title, techno
 
       {/* Category Title with Colored Line */}
       <div className="text-center">
-        <h3 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-xl mb-2">{title}</h3>
+        <h3 className="text-3xl font-extrabold text-primary sm:text-xl mb-2">{title}</h3>
         <div className={`w-12 h-0.5 ${lineColor} rounded-full mx-auto`}></div>
       </div>
 
@@ -209,7 +209,7 @@ const TechnologyCategory = ({ IconComponent, iconColor, lineColor, title, techno
       </div>
 
       {/* Years Badge */}
-      <Badge className="bg-accent dark:bg-accent-dark text-background dark:text-background-dark font-medium px-3 py-1">{t(yearsKey)}</Badge>
+      <Badge className="bg-accent text-background font-medium px-3 py-1">{t(yearsKey)}</Badge>
     </div>
   );
 };
@@ -280,7 +280,7 @@ const TechStack = () => {
     <section className="mt-14 lg:w-full">
       {/* Header */}
       <div className=" mb-12">
-        <h3 className="text-3xl font-bold text-primary dark:text-primary-dark underline-heading mb-4">{t('myToolbox')}</h3>
+        <h3 className="text-3xl font-bold text-primary underline-heading mb-4">{t('myToolbox')}</h3>
         <p className="mt-1 font-medium">{tToolbox('description')}</p>
       </div>
 
@@ -301,7 +301,7 @@ const TechStack = () => {
 
       {/* Note */}
       <div className="mt-10 mb-10 text-center">
-        <p className="text-sm text-muted-foreground dark:text-muted-foreground">
+        <p className="text-sm text-muted-foreground">
           <Lightbulb className="inline-block mr-1 relative -top-1" />
           {tToolbox('hoverTip')}
         </p>

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -19,7 +19,7 @@ const ThemeToggle = () => {
   return (
     <button
       onClick={toggleTheme}
-      className="ml-4 p-2 rounded-full border border-primary dark:text-secondary-dark bg-background dark:bg-background-dark text-secondary dark:border-primary-dark-foreground hover:bg-primary dark:hover:bg-primary-dark dark:hover:bg-gray-600 hover:text-foreground-dark dark:hover:text-background-dark"
+      className="ml-4 p-2 rounded-full border border-primary bg-background text-secondary hover:bg-primary hover:text-primary-foreground"
       aria-label="Toggle theme"
     >
       <Icon icon={theme === 'light' ? 'ph:moon' : 'ph:sun'} className="w-5 h-5" />

--- a/components/WorkExperience.tsx
+++ b/components/WorkExperience.tsx
@@ -13,30 +13,30 @@ const WorkExperience = () => {
 
   return (
     <div className="pt-14 mt-12 sm:max-w-2xl mx-auto">
-      <h2 className="text-3xl font-extrabold text-primary dark:text-primary-dark sm:text-3xl underline-heading mb-4">{t('title')}</h2>
-      <p className="text-secondary dark:text-secondary-dark text-lg font-medium mb-4">{t('description')}</p>
+      <h2 className="text-3xl font-extrabold text-primary sm:text-3xl underline-heading mb-4">{t('title')}</h2>
+      <p className="text-secondary text-lg font-medium mb-4">{t('description')}</p>
       <div className="flex flex-col sm:flex-row">
         <div className=" w-full sm:w-1/5 lg:pr-4 pt-6">
           <CompanySelector companies={companies} activeTab={activeTab} setActiveTab={setActiveTab} />
         </div>
         <div className="w-full sm:w-4/5">
           <Card className="border-none bg-transparent shadow-none">
-            <CardContent className="pt-6 text-foreground dark:text-foreground-dark border-none">
-              <h3 className="text-xl font-semibold text-primary dark:text-primary-dark">{companies[activeTab].role}</h3>
-              <p className="text-sm text-secondary dark:text-secondary-dark">{companies[activeTab].period}</p>
-              <p className="text-sm text-accent dark:text-accent-dark mb-4">{companies[activeTab].location}</p>
-              <ul className="text-base dark:text-foreground-dark font-medium mb-4">
+            <CardContent className="pt-6 text-foreground border-none">
+              <h3 className="text-xl font-semibold text-primary">{companies[activeTab].role}</h3>
+              <p className="text-sm text-secondary">{companies[activeTab].period}</p>
+              <p className="text-sm text-accent mb-4">{companies[activeTab].location}</p>
+              <ul className="text-base text-foreground font-medium mb-4">
                 {t.rich(`companies.${activeTab}.description`, {
                   li: chunks => (
                     <li className="mb-2">
-                      <Icon icon="ph:caret-right" className="w-5 h-5 inline-block text-secondary dark:text-secondary-dark" /> {chunks}
+                      <Icon icon="ph:caret-right" className="w-5 h-5 inline-block text-secondary" /> {chunks}
                     </li>
                   ),
                 })}
               </ul>
               <ul className="flex flex-wrap gap-2 pt-4">
                 {companies[activeTab].tags.map((tag: string, index: number) => (
-                  <li key={index} className="text-xs bg-muted dark:bg-muted-dark px-2 py-1 rounded text-primary dark:text-primary-dark">
+                  <li key={index} className="text-xs bg-muted px-2 py-1 rounded text-primary">
                     {tag}
                   </li>
                 ))}

--- a/components/chat-widget/ChatHeader.tsx
+++ b/components/chat-widget/ChatHeader.tsx
@@ -12,16 +12,16 @@ export const ChatHeader = ({ onClose }: ChatHeaderProps) => {
   const t = useTranslations('chatWidget');
 
   return (
-    <div className="p-6 border-b border-muted dark:border-muted-dark bg-background/40 dark:bg-background-dark/60 flex items-center justify-between">
+    <div className="p-6 border-b border-muted bg-background/40 dark:bg-background/60 flex items-center justify-between">
       <div className="flex items-center space-x-3">
         <div className="relative">
-          <div className="w-10 h-10 bg-gradient-to-br from-primary-dark to-secondary-dark dark:from-primary-dark dark:to-secondary-dark rounded-full flex items-center justify-center">
-            <Bot className="w-5 h-5 text-primary" />
+          <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-full flex items-center justify-center">
+            <Bot className="w-5 h-5 text-primary-foreground" />
           </div>
-          <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-accent dark:bg-accent-dark rounded-full border-2 border-background dark:border-background-dark animate-[pulse_2s_ease-in-out_infinite]" />
+          <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-accent rounded-full border-2 border-background animate-[pulse_2s_ease-in-out_infinite]" />
         </div>
         <div>
-          <h3 className="font-semibold text-lg text-foreground dark:text-primary-dark">{t('title')}</h3>
+          <h3 className="font-semibold text-lg text-foreground">{t('title')}</h3>
           <p className="text-sm text-muted-foreground">{t('subtitle')}</p>
         </div>
       </div>

--- a/components/chat-widget/ChatInput.tsx
+++ b/components/chat-widget/ChatInput.tsx
@@ -17,7 +17,7 @@ export const ChatInput = ({ inputMessage, setInputMessage, onSendMessage, onRese
   const t = useTranslations('chatWidget');
 
   return (
-    <div className="p-6 border-t border-muted dark:border-muted-dark bg-background/40 dark:bg-background-dark/60">
+    <div className="p-6 border-t border-muted bg-background/40 dark:bg-background/60">
       <div className="flex space-x-3">
         <div className="flex-1 relative">
           <input
@@ -27,7 +27,7 @@ export const ChatInput = ({ inputMessage, setInputMessage, onSendMessage, onRese
             onChange={e => setInputMessage(e.target.value)}
             onKeyPress={onKeyPress}
             placeholder={t('placeholder')}
-            className="w-full px-4 py-3 rounded-2xl border border-muted dark:border-muted-dark bg-background dark:bg-background-dark text-foreground dark:text-foreground-dark placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark focus:border-transparent transition-all duration-200"
+            className="w-full px-4 py-3 rounded-2xl border border-muted bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all duration-200"
             disabled={isLoading}
             maxLength={500}
             aria-label={t('placeholder') || 'Chat message input'}
@@ -40,10 +40,10 @@ export const ChatInput = ({ inputMessage, setInputMessage, onSendMessage, onRese
         <Button
           onClick={onSendMessage}
           disabled={!inputMessage.trim() || isLoading}
-          className="h-12 w-12 rounded-full dark:text-secondary bg-primary dark:bg-primary-dark hover:bg-secondary dark:hover:bg-secondary-dark disabled:opacity-50 transition-all duration-200 hover:scale-105 disabled:hover:scale-100"
+          className="h-12 w-12 rounded-full bg-primary hover:bg-secondary disabled:opacity-50 transition-all duration-200 hover:scale-105 disabled:hover:scale-100"
           aria-label="Send message"
         >
-          <Send className="h-5 w-5 text-primary" aria-hidden="true" />
+          <Send className="h-5 w-5 text-primary-foreground" aria-hidden="true" />
         </Button>
       </div>
 
@@ -51,7 +51,7 @@ export const ChatInput = ({ inputMessage, setInputMessage, onSendMessage, onRese
         {t('disclaimer')}
         <button
           onClick={onReset}
-          className="ml-1 text-primary dark:text-primary-dark hover:text-secondary dark:hover:text-secondary-dark underline"
+          className="ml-1 text-primary hover:text-secondary underline"
         >
           {t('resetConversation')}
         </button>

--- a/components/chat-widget/ChatWidget.tsx
+++ b/components/chat-widget/ChatWidget.tsx
@@ -46,7 +46,7 @@ export default function ModernChatWidget() {
 
       {/* Chat Container */}
       <div className="fixed inset-4 md:inset-8 lg:inset-16 z-50 flex items-center justify-center">
-        <Card className="w-full max-w-4xl h-full max-h-[800px] flex flex-col shadow-2xl border-0 overflow-hidden bg-background/80 dark:bg-background-dark/95 backdrop-blur-xl">
+        <Card className="w-full max-w-4xl h-full max-h-[800px] flex flex-col shadow-2xl border-0 overflow-hidden bg-background/80 backdrop-blur-xl">
           <ChatHeader onClose={closeChat} />
 
           {/* Messages Area */}

--- a/components/chat-widget/ChatWidgetBar.tsx
+++ b/components/chat-widget/ChatWidgetBar.tsx
@@ -26,15 +26,15 @@ export const ChatWidgetBar = ({ isVisible, onOpen }: ChatWidgetBarProps) => {
     >
       <div className="relative max-w-4xl mx-auto group">
         {/* Gradient glow background - slower pulse */}
-        <div className="absolute -inset-1 bg-gradient-to-r from-primary via-secondary to-accent dark:from-primary-dark dark:via-secondary-dark dark:to-accent-dark rounded-xl blur-sm opacity-60 group-hover:opacity-80 animate-[pulse_3s_ease-in-out_infinite] transition-opacity duration-500" />
+        <div className="absolute -inset-1 bg-gradient-to-r from-primary via-secondary to-accent rounded-xl blur-sm opacity-60 group-hover:opacity-80 animate-[pulse_3s_ease-in-out_infinite] transition-opacity duration-500" />
 
         {/* Enhanced glow on hover */}
-        <div className="absolute -inset-2 bg-gradient-to-r from-primary/50 via-secondary/50 to-accent/50 dark:from-primary-dark/50 dark:via-secondary-dark/50 dark:to-accent-dark/50 rounded-xl blur-md opacity-0 group-hover:opacity-60 transition-all duration-500" />
+        <div className="absolute -inset-2 bg-gradient-to-r from-primary/50 via-secondary/50 to-accent/50 rounded-xl blur-md opacity-0 group-hover:opacity-60 transition-all duration-500" />
 
         {/* Main input-style container */}
         <button
           type="button"
-          className="relative w-full bg-background/70 dark:bg-background-dark/90 backdrop-blur-lg rounded-xl border border-muted/30 dark:border-muted-dark/30 px-4 py-3 transition-all duration-300 group-hover:scale-[1.02] group-hover:bg-background/80 dark:group-hover:bg-background-dark/95 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary dark:focus:ring-primary-dark focus:ring-offset-2"
+          className="relative w-full bg-background/70 dark:bg-background/90 backdrop-blur-lg rounded-xl border border-muted/30 px-4 py-3 transition-all duration-300 group-hover:scale-[1.02] group-hover:bg-background/80 dark:group-hover:bg-background/95 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
           onClick={onOpen}
           onKeyDown={handleKeyDown}
           aria-label={t('placeholder') || 'Open chat widget'}
@@ -42,15 +42,15 @@ export const ChatWidgetBar = ({ isVisible, onOpen }: ChatWidgetBarProps) => {
           <div className="flex items-center space-x-4">
             {/* Chat icon */}
             <div className="relative flex-shrink-0">
-              <div className="w-8 h-8 bg-gradient-to-br from-primary-dark to-secondary-dark dark:from-primary-dark dark:to-secondary-dark rounded-full flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
-                <MessageCircle className="w-4 h-4 text-primary" />
+              <div className="w-8 h-8 bg-gradient-to-br from-primary to-secondary rounded-full flex items-center justify-center group-hover:scale-110 transition-transform duration-300">
+                <MessageCircle className="w-4 h-4 text-primary-foreground" />
               </div>
-              <div className="absolute top-0 -right-1 w-3 h-3 bg-accent dark:bg-accent-dark rounded-full animate-[pulse_2s_ease-in-out_infinite] border border-background dark:border-background-dark" />
+              <div className="absolute top-0 -right-1 w-3 h-3 bg-accent rounded-full animate-[pulse_2s_ease-in-out_infinite] border border-background" />
             </div>
 
             {/* Input-style text */}
             <div className="flex-1 min-w-0">
-              <div className="text-muted-foreground text-sm group-hover:text-foreground dark:group-hover:text-foreground-dark transition-colors duration-300">
+              <div className="text-muted-foreground text-sm group-hover:text-foreground transition-colors duration-300">
                 {t('placeholder')}
               </div>
             </div>
@@ -58,19 +58,19 @@ export const ChatWidgetBar = ({ isVisible, onOpen }: ChatWidgetBarProps) => {
             {/* Right side elements */}
             <div className="flex items-center space-x-3 flex-shrink-0">
               <div className="hidden sm:flex items-center space-x-2 text-muted-foreground text-xs">
-                <Sparkles className="w-3 h-3 animate-[pulse_2.5s_ease-in-out_infinite] text-primary dark:text-primary-dark" />
+                <Sparkles className="w-3 h-3 animate-[pulse_2.5s_ease-in-out_infinite] text-primary" />
                 <span>{t('aiAssistant')}</span>
               </div>
 
               {/* Send-style icon */}
-              <div className="w-6 h-6 bg-primary/10 dark:bg-primary-dark/10 rounded-full flex items-center justify-center group-hover:bg-primary/20 dark:group-hover:bg-primary-dark/20 transition-colors duration-300">
-                <Bot className="w-3 h-3 text-primary dark:text-primary-dark" />
+              <div className="w-6 h-6 bg-primary/10 rounded-full flex items-center justify-center group-hover:bg-primary/20 transition-colors duration-300">
+                <Bot className="w-3 h-3 text-primary" />
               </div>
             </div>
           </div>
 
           {/* Subtle bottom border glow */}
-          <div className="absolute bottom-0 left-4 right-4 h-px bg-gradient-to-r from-transparent via-primary/30 dark:via-primary-dark/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
+          <div className="absolute bottom-0 left-4 right-4 h-px bg-gradient-to-r from-transparent via-primary/30 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-500" />
         </button>
       </div>
     </div>

--- a/components/chat-widget/LoadingIndicator.tsx
+++ b/components/chat-widget/LoadingIndicator.tsx
@@ -8,15 +8,15 @@ export const LoadingIndicator = () => {
 
   return (
     <div className="flex items-start space-x-3">
-      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-secondary to-primary dark:from-secondary-dark dark:to-primary-dark flex items-center justify-center">
-        <Bot className="w-4 h-4 text-foreground-dark dark:text-primary" />
+      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-secondary to-primary flex items-center justify-center">
+        <Bot className="w-4 h-4 text-primary-foreground" />
       </div>
-      <div className="p-4 rounded-2xl rounded-bl-md bg-muted dark:bg-muted-dark border border-muted dark:border-muted-dark">
+      <div className="p-4 rounded-2xl rounded-bl-md bg-muted border border-muted">
         <div className="flex items-center space-x-2">
           <div className="flex space-x-1">
-            <div className="w-2 h-2 bg-primary dark:bg-primary-dark rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-            <div className="w-2 h-2 bg-primary dark:bg-primary-dark rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-            <div className="w-2 h-2 bg-primary dark:bg-primary-dark rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+            <div className="w-2 h-2 bg-primary rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+            <div className="w-2 h-2 bg-primary rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+            <div className="w-2 h-2 bg-primary rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
           </div>
           <span className="text-sm text-muted-foreground">{t('thinking')}</span>
         </div>

--- a/components/chat-widget/MessageBubble.tsx
+++ b/components/chat-widget/MessageBubble.tsx
@@ -16,14 +16,14 @@ export const MessageBubble = ({ message }: MessageBubbleProps) => {
       <div
         className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 ${
           isUser
-            ? 'bg-primary dark:bg-primary-dark'
-            : 'bg-gradient-to-br from-secondary to-primary dark:from-secondary-dark dark:to-primary-dark'
+            ? 'bg-primary'
+            : 'bg-gradient-to-br from-secondary to-primary'
         }`}
       >
         {isUser ? (
-          <User className="w-4 h-4 text-foreground-dark dark:text-primary" />
+          <User className="w-4 h-4 text-primary-foreground" />
         ) : (
-          <Bot className="w-4 h-4 text-foreground-dark dark:text-primary" />
+          <Bot className="w-4 h-4 text-primary-foreground" />
         )}
       </div>
 
@@ -32,8 +32,8 @@ export const MessageBubble = ({ message }: MessageBubbleProps) => {
         <div
           className={`inline-block p-4 rounded-2xl shadow-sm ${
             isUser
-              ? 'bg-primary dark:bg-primary-dark text-white dark:text-slate-900 rounded-br-md'
-              : 'bg-muted dark:bg-muted-dark text-foreground dark:text-foreground-dark rounded-bl-md border border-muted dark:border-muted-dark'
+              ? 'bg-primary text-white dark:text-slate-900 rounded-br-md'
+              : 'bg-muted text-foreground rounded-bl-md border border-muted'
           }`}
         >
           <p className="text-sm leading-relaxed whitespace-pre-wrap">{message.content}</p>

--- a/components/chat-widget/TypingIndicator.tsx
+++ b/components/chat-widget/TypingIndicator.tsx
@@ -9,12 +9,12 @@ interface TypingIndicatorProps {
 export const TypingIndicator = ({ message }: TypingIndicatorProps) => {
   return (
     <div className="flex items-start space-x-3">
-      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-secondary to-primary dark:from-secondary-dark dark:to-primary-dark flex items-center justify-center flex-shrink-0">
-        <Bot className="w-4 h-4 text-foreground-dark dark:text-primary" />
+      <div className="w-8 h-8 rounded-full bg-gradient-to-br from-secondary to-primary flex items-center justify-center flex-shrink-0">
+        <Bot className="w-4 h-4 text-primary-foreground" />
       </div>
       <div className="flex-1 max-w-[80%]">
-        <div className="inline-block p-4 rounded-2xl rounded-bl-md bg-muted dark:bg-muted-dark border border-muted dark:border-muted-dark shadow-sm">
-          <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground dark:text-foreground-dark">
+        <div className="inline-block p-4 rounded-2xl rounded-bl-md bg-muted border border-muted shadow-sm">
+          <p className="text-sm leading-relaxed whitespace-pre-wrap text-foreground">
             {message}
             <span className="animate-pulse">|</span>
           </p>

--- a/components/chat-widget/WelcomeMessage.tsx
+++ b/components/chat-widget/WelcomeMessage.tsx
@@ -16,8 +16,8 @@ export const WelcomeMessage = ({ suggestions, suggestionsLoading, onSendMessage 
   return (
     <div className="space-y-6">
       <div className="text-center py-8 text-muted-foreground">
-        <Sparkles className="w-12 h-12 mx-auto mb-4 text-primary dark:text-primary-dark animate-[pulse_2.5s_ease-in-out_infinite]" />
-        <h4 className="text-lg font-medium mb-2 text-foreground dark:text-foreground-dark">{t('welcomeMessage')}</h4>
+        <Sparkles className="w-12 h-12 mx-auto mb-4 text-primary animate-[pulse_2.5s_ease-in-out_infinite]" />
+        <h4 className="text-lg font-medium mb-2 text-foreground">{t('welcomeMessage')}</h4>
         <p className="text-sm">{t('description')}</p>
       </div>
 
@@ -27,18 +27,18 @@ export const WelcomeMessage = ({ suggestions, suggestionsLoading, onSendMessage 
             Array.from({ length: 6 }).map((_, index) => (
               <div
                 key={index}
-                className="p-4 h-14 rounded-lg border border-muted dark:border-muted-dark bg-muted/50 dark:bg-muted-dark/50 animate-pulse"
+                className="p-4 h-14 rounded-lg border border-muted bg-muted/50 animate-pulse"
               />
             ))
           : suggestions.slice(0, 6).map((suggestion: string, index: number) => (
               <Button
                 key={index}
                 variant="outline"
-                className="p-4 h-auto text-left justify-start text-sm transition-all duration-200 hover:scale-[1.02] border-muted dark:border-muted-dark hover:border-primary/50 dark:hover:border-primary-dark/50 hover:bg-primary/5 dark:hover:bg-primary-dark/5 bg-background dark:bg-background-dark text-foreground dark:text-foreground-dark break-words whitespace-normal min-h-[3.5rem]"
+                className="p-4 h-auto text-left justify-start text-sm transition-all duration-200 hover:scale-[1.02] border-muted hover:border-primary/50 hover:bg-primary/5 bg-background text-foreground break-words whitespace-normal min-h-[3.5rem]"
                 onClick={() => onSendMessage(suggestion)}
               >
-                <MessageCircle className="w-4 h-4 mr-3 text-primary dark:text-primary-dark flex-shrink-0 mt-0.5" />
-                <span className="text-foreground dark:text-foreground-dark text-left leading-tight">{suggestion}</span>
+                <MessageCircle className="w-4 h-4 mr-3 text-primary flex-shrink-0 mt-0.5" />
+                <span className="text-foreground text-left leading-tight">{suggestion}</span>
               </Button>
             ))}
       </div>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -8,7 +8,7 @@ const Footer = () => {
       <div className="container mx-auto px-6 py-4">
         <div className="text-center">
           <a
-            className="text-accent dark:text-accent-dark hover:underline"
+            className="text-accent hover:underline"
             href="https://github.com/craigraphics/craigraphics-next-2024"
             target="_blank"
             rel="noopener noreferrer"

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -22,15 +22,15 @@ const NavItems = ({ closeMenu }: { closeMenu?: () => void }) => {
       <Link href={`/${locale}/`} onClick={closeMenu}>
         {t('home')}
       </Link>
-      <Separator orientation="vertical" className="bg-muted-dark dark:bg-muted-dark h-5 hidden md:block" />
+      <Separator orientation="vertical" className="bg-muted h-5 hidden md:block" />
       <Link href={`/${locale}/work`} onClick={closeMenu}>
         {t('projects')}
       </Link>
-      <Separator orientation="vertical" className="bg-muted-dark dark:bg-muted-dark h-5 hidden md:block" />
+      <Separator orientation="vertical" className="bg-muted h-5 hidden md:block" />
       <Link href={`/${locale}/blog`} onClick={closeMenu}>
         {t('blog')}
       </Link>
-      <Separator orientation="vertical" className="bg-muted-dark dark:bg-muted-dark h-5 hidden md:block" />
+      <Separator orientation="vertical" className="bg-muted h-5 hidden md:block" />
       <Link href={`/${locale}/contact`} onClick={closeMenu}>
         {t('contact')}
       </Link>
@@ -74,7 +74,7 @@ const Header = () => {
   return (
     <header
       className={`fixed top-0 left-0 w-full
-        border-b border-muted dark:border-muted-dark
+        border-b border-muted
         bg-white dark:bg-gray-800 bg-opacity-50 dark:bg-opacity-50
         transition-transform duration-300 z-10
         ${isVisible ? 'translate-y-0' : '-translate-y-full'} backdrop-filter backdrop-blur-lg`}
@@ -95,15 +95,14 @@ const Header = () => {
           <div className="flex items-center space-x-4">
             <ThemeToggle />
             <Select onValueChange={changeLanguage} defaultValue={locale}>
-              <SelectTrigger className="w-[80px] dark:bg-background-dark border-primary border dark:border-primary-dark dark:text-secondary-dark">
+              <SelectTrigger className="w-[80px] bg-background border-primary border">
                 <SelectValue placeholder="Lang" />
               </SelectTrigger>
-              <SelectContent className="bg-background dark:bg-background-dark ">
+              <SelectContent className="bg-background">
                 <SelectItem
-                  className=" 
-                  dark:hover:text-primary dark:hover:bg-secondary-dark
-                  data-[state=checked]:bg-primary data-[state=checked]:text-foreground-dark
-                  dark:data-[state=checked]:bg-primary-dark dark:data-[state=checked]:text-slate-800  
+                  className="
+                  hover:text-primary hover:bg-secondary
+                  data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground
                   cursor-pointer"
                   value="en"
                 >
@@ -111,9 +110,8 @@ const Header = () => {
                 </SelectItem>
                 <SelectItem
                   className="
-                  dark:hover:text-primary dark:hover:bg-secondary-dark
-                  data-[state=checked]:bg-primary data-[state=checked]:text-foreground-dark
-                  dark:data-[state=checked]:bg-primary-dark dark:data-[state=checked]:text-slate-800  
+                  hover:text-primary hover:bg-secondary
+                  data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground
                   cursor-pointer"
                   value="es"
                 >
@@ -128,26 +126,25 @@ const Header = () => {
                 <Button
                   variant="ghost"
                   size="icon"
-                  className="md:hidden text-secondary dark:text-secondary-dark 
-                  hover:bg-secondary dark:hover:bg-primary-dark
-                  hover:text-foreground-dark dark:hover:text-primary"
+                  className="md:hidden text-secondary
+                  hover:bg-secondary hover:text-primary-foreground"
                 >
                   <Menu className="h-6 w-6" />
                   <span className="sr-only">{t('open_menu')}</span>
                 </Button>
               </SheetTrigger>
-              <SheetContent side="right" className="w-[240px] sm:w-[300px] bg-background-dark/70">
+              <SheetContent side="right" className="w-[240px] sm:w-[300px] bg-background/80">
                 <SheetHeader className="mb-4">
                   <SheetTitle>{t('menu')}</SheetTitle>
                   <SheetDescription className="pb-2">{t('menu_description')}</SheetDescription>
-                  <Separator orientation="horizontal" className="bg-accent dark:bg-accent-dark" />
+                  <Separator orientation="horizontal" className="bg-accent" />
                 </SheetHeader>
                 <div className="absolute top-1 right-1 ">
                   <SheetClose asChild>
                     <Button
                       variant="ghost"
                       size="icon"
-                      className="text-secondary dark:text-secondary-dark hover:bg-transparent hover:text-primary hover:dark:text-primary-dark"
+                      className="text-secondary hover:bg-transparent hover:text-primary"
                     >
                       <X className="h-6 w-6" />
                       <span className="sr-only">{t('close_menu')}</span>

--- a/components/layout/Layout.tsx
+++ b/components/layout/Layout.tsx
@@ -12,7 +12,7 @@ const Layout = ({ children }: LayoutProps) => {
     <div className="flex flex-col min-h-screen ">
       <a
         href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary dark:focus:bg-primary-dark focus:text-foreground-dark dark:focus:text-background-dark focus:rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary dark:focus:ring-primary-dark"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-primary focus:text-primary-foreground focus:rounded-md focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
       >
         Skip to main content
       </a>

--- a/components/layout/Logo.tsx
+++ b/components/layout/Logo.tsx
@@ -6,13 +6,13 @@ const Logo = () => (
       </g>
       <g>
         <path
-          className="fill-primary dark:fill-background"
+          className="fill-primary"
           d="M13,2c6.07,0,11,4.93,11,11s-4.93,11-11,11S2,19.07,2,13S6.93,2,13,2 M13,0C5.82,0,0,5.82,0,13
 		c0,7.18,5.82,13,13,13s13-5.82,13-13C26,5.82,20.18,0,13,0L13,0z"
         />
       </g>
     </svg>
-    <span className="ml-1 font-medium text-primary dark:text-primary-dark">craigraphics</span>
+    <span className="ml-1 font-medium text-primary">craigraphics</span>
   </>
 );
 

--- a/components/ui/NavLink.tsx
+++ b/components/ui/NavLink.tsx
@@ -10,7 +10,7 @@ const NavLink: React.FC<NavLinkProps> = ({ href, onClick, children }) => {
   return (
     <Link
       href={href}
-      className="block py-2 font-medium text-secondary dark:text-secondary-dark hover:text-primary dark:hover:text-primary-dark transition-colors"
+      className="block py-2 font-medium text-secondary hover:text-primary transition-colors"
       onClick={onClick}
     >
       {children}

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -13,34 +13,22 @@ const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setTheme] = useState<Theme>('light');
-  const [mounting, setMounting] = useState(true);
 
   useEffect(() => {
-    const storedTheme = localStorage.getItem('theme') as Theme | null;
-    if (storedTheme) {
-      setTheme(storedTheme);
-    } else {
-      const userMedia = window.matchMedia('(prefers-color-scheme: dark)');
-      if (userMedia.matches) {
-        setTheme('dark');
-      }
-    }
-    setMounting(false);
+    const stored = localStorage.getItem('theme') as Theme | null;
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    setTheme(stored || (prefersDark ? 'dark' : 'light'));
   }, []);
 
   useEffect(() => {
-    if (!mounting) {
-      localStorage.setItem('theme', theme);
-      document.documentElement.classList.remove('light', 'dark');
-      document.documentElement.classList.add(theme);
-    }
-  }, [theme, mounting]);
+    localStorage.setItem('theme', theme);
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+  }, [theme]);
 
   const toggleTheme = () => {
     setTheme(prevTheme => (prevTheme === 'light' ? 'dark' : 'light'));
   };
-
-  if (mounting) return null; // Prevent any render until the theme is determined
 
   return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,12 +3,6 @@ import type { Config } from 'tailwindcss';
 const config: Config = {
   darkMode: ['class'],
   content: ['./pages/**/*.{js,ts,jsx,tsx,mdx}', './components/**/*.{js,ts,jsx,tsx,mdx}', './app/**/*.{js,ts,jsx,tsx,mdx}'],
-  safelist: [
-    {
-      pattern: /^(bg|text|border)-(white|gray|black)/,
-      variants: ['dark'],
-    },
-  ],
   theme: {
     container: {
       center: true,
@@ -22,39 +16,27 @@ const config: Config = {
         border: 'hsl(var(--border))',
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
-        background: {
-          DEFAULT: 'hsl(var(--background-light))',
-          dark: 'hsl(var(--background-dark))',
-        },
-        foreground: {
-          DEFAULT: 'hsl(var(--foreground-light))',
-          dark: 'hsl(var(--foreground-dark))',
-        },
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
         primary: {
-          DEFAULT: 'hsl(var(--primary-light))',
-          foreground: 'hsl(var(--primary-foreground-light))',
-          dark: 'hsl(var(--primary-dark))',
-          'dark-foreground': 'hsl(var(--primary-foreground-dark))',
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary-light))',
-          foreground: 'hsl(var(--secondary-foreground-light))',
-          dark: 'hsl(var(--secondary-dark))',
-          'dark-foreground': 'hsl(var(--secondary-foreground-dark))',
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
         },
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
           foreground: 'hsl(var(--destructive-foreground))',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted-light))',
+          DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',
-          dark: 'hsl(var(--muted-dark))',
         },
         accent: {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
-          dark: 'hsl(var(--accent-dark))',
         },
         popover: {
           DEFAULT: 'hsl(var(--popover))',


### PR DESCRIPTION
Replace the dual-token architecture (--primary-light/--primary-dark, bg-primary dark:bg-primary-dark) with the standard shadcn/ui pattern where :root defines light values and .dark overrides them. All 29 component and config files now use single adaptive tokens (e.g. text-primary, bg-background) instead of paired dark: variants.

Also remove the mounting null-guard in ThemeContext and replace it with a synchronous inline <script> in <head> that sets the theme class before first paint, eliminating the blank-page flash on load. Restore dark-mode opacity values on chat widget surfaces that were lost during the collapse of split opacity utilities.