### PR TITLE
feat: add honeypot + Cloudflare Turnstile spam protection to contact form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local-only files (not for the repo)
+.playwright-mcp/
+RESEND_SETUP.md
+*.mp3
+squarespace_backup_codes_*.txt

--- a/SPAM_PROTECTION.md
+++ b/SPAM_PROTECTION.md
@@ -1,0 +1,56 @@
+# Contact Form Spam Protection
+
+The contact form is protected by two layers, both nearly invisible to real users:
+
+1. **Honeypot field** — a hidden `company` input real users never see. Bots auto-fill it; the server silently drops those submissions (returns a success-looking `200` so bots don't learn they were caught). Zero third-party script, zero user friction.
+2. **Cloudflare Turnstile** (managed mode) — a lightweight, privacy-friendly captcha that auto-resolves in the background for real users. Verified server-side so it can't be bypassed by POSTing directly to the API. Free at unlimited volume.
+
+## Where it lives
+
+- Client widget + honeypot: `components/Contact.tsx`
+- Server-side honeypot check + Turnstile verification + input validation: `app/api/send-email/route.ts`
+
+## Setup
+
+### 1. Create a free Turnstile site
+
+1. Go to the [Cloudflare dashboard](https://dash.cloudflare.com) → **Turnstile**.
+2. Add a widget. Set **Widget Mode** to **Managed** (least intrusive).
+3. Add your domains: `craigraphics.com`, plus `localhost` and `127.0.0.1` for local dev.
+4. Copy the generated **Site Key** (public) and **Secret Key** (private).
+
+### 2. Set environment variables
+
+Add to `.env.local` (local) and your Vercel project env (production):
+
+```env
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=0x...your_site_key
+TURNSTILE_SECRET_KEY=0x...your_secret_key
+```
+
+| Variable                          | Visibility | Used by                          |
+| --------------------------------- | ---------- | -------------------------------- |
+| `NEXT_PUBLIC_TURNSTILE_SITE_KEY`  | Public     | Client widget in `Contact.tsx`   |
+| `TURNSTILE_SECRET_KEY`            | Private    | Server verification in the route |
+
+### 3. Local development / testing
+
+Cloudflare provides official test keys that don't require a registered domain. `.env.local` ships with the **always-pass** pair by default:
+
+```env
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+TURNSTILE_SECRET_KEY=1x0000000000000000000000000000000AA
+```
+
+Other useful test keys:
+
+- **Always blocks:** site `2x00000000000000000000AB`, secret `2x0000000000000000000000000000000AA`
+- **Forces interactive challenge:** site `3x00000000000000000000FF`
+
+Replace with real keys before production.
+
+## Behaviour notes
+
+- If `NEXT_PUBLIC_TURNSTILE_SITE_KEY` is unset, the widget doesn't render and the submit button stays enabled — but the server still requires a valid token, so submissions fail with `400`. Always set both keys.
+- The Turnstile token is single-use; the form resets the widget after each submit (success or error) so users can retry.
+- The server returns `400 Captcha verification failed` on a missing/invalid token, and `400 Email and message are required` on empty input.

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -10,6 +10,31 @@ function escapeHtml(str: string): string {
     .replace(/'/g, '&#x27;');
 }
 
+async function verifyTurnstile(token: string, remoteip: string | null): Promise<boolean> {
+  const secret = process.env.TURNSTILE_SECRET_KEY;
+  if (!secret) {
+    console.error('Turnstile secret key is missing');
+    return false;
+  }
+
+  try {
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        secret,
+        response: token,
+        ...(remoteip ? { remoteip } : {}),
+      }),
+    });
+    const outcome = (await res.json()) as { success: boolean };
+    return outcome.success === true;
+  } catch (err) {
+    console.error('Turnstile verification request failed:', err);
+    return false;
+  }
+}
+
 export async function POST(req: Request) {
   console.log('API route hit - Starting email send process');
 
@@ -26,6 +51,31 @@ export async function POST(req: Request) {
     // Log the request body
     const body = await req.json();
 
+    // Honeypot: real users never fill this hidden field. Bots do.
+    // Silently accept (200) but drop the message so bots don't learn they were caught.
+    if (typeof body.company === 'string' && body.company.trim() !== '') {
+      console.warn('Honeypot triggered - dropping spam submission');
+      return NextResponse.json({ message: 'Email sent successfully' }, { status: 200 });
+    }
+
+    // Basic input validation
+    const email = typeof body.email === 'string' ? body.email.trim() : '';
+    const message = typeof body.message === 'string' ? body.message.trim() : '';
+    if (!email || !message) {
+      return NextResponse.json({ message: 'Email and message are required' }, { status: 400 });
+    }
+
+    // Captcha verification (server-side enforcement — the client check is not enough)
+    const token = typeof body.token === 'string' ? body.token : '';
+    if (!token) {
+      return NextResponse.json({ message: 'Captcha verification required' }, { status: 400 });
+    }
+    const remoteip = req.headers.get('cf-connecting-ip') ?? req.headers.get('x-forwarded-for');
+    const captchaOk = await verifyTurnstile(token, remoteip);
+    if (!captchaOk) {
+      return NextResponse.json({ message: 'Captcha verification failed' }, { status: 400 });
+    }
+
     // Check if required environment variables exist
     if (!process.env.TO_EMAIL || !process.env.FROM_EMAIL) {
       console.error('Missing required email configuration:', {
@@ -36,13 +86,13 @@ export async function POST(req: Request) {
     }
 
     // Construct email message
-    const safeEmail = escapeHtml(body.email);
-    const safeMessage = escapeHtml(body.message);
+    const safeEmail = escapeHtml(email);
+    const safeMessage = escapeHtml(message);
     const { data, error } = await resend.emails.send({
       from: process.env.FROM_EMAIL,
       to: [process.env.TO_EMAIL],
       subject: 'New Message from craigraphics.com',
-      text: `From: ${body.email}\nMessage: ${body.message}`,
+      text: `From: ${email}\nMessage: ${message}`,
       html: `
         <h2>New Contact Form Submission</h2>
         <p><strong>From:</strong> ${safeEmail}</p>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import React, { useState, FormEvent, FC } from 'react';
+import React, { useState, useRef, FormEvent, FC } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useTranslations } from 'next-intl';
+import { Turnstile, TurnstileInstance } from '@marsidev/react-turnstile';
 import { useToast } from '@/hooks/use-toast';
 
 import { Textarea } from '@/components/ui/textarea';
@@ -14,6 +15,8 @@ import { Toaster } from '@/components/ui/toaster';
 interface EmailFormData {
   email: string;
   message: string;
+  company: string; // honeypot — must stay empty for real users
+  token: string; // Cloudflare Turnstile token
 }
 
 interface EmailResponse {
@@ -40,14 +43,22 @@ const sendEmail = async (formData: EmailFormData): Promise<EmailResponse> => {
 const EmailForm: FC = () => {
   const [email, setEmail] = useState<string>('');
   const [message, setMessage] = useState<string>('');
+  const [company, setCompany] = useState<string>(''); // honeypot
+  const [token, setToken] = useState<string>('');
+  const turnstileRef = useRef<TurnstileInstance>(null);
   const t = useTranslations('contact');
   const { toast } = useToast();
+
+  const siteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY;
 
   const mutation = useMutation({
     mutationFn: sendEmail,
     onSuccess: () => {
       setEmail('');
       setMessage('');
+      setCompany('');
+      setToken('');
+      turnstileRef.current?.reset();
     },
   });
 
@@ -55,7 +66,7 @@ const EmailForm: FC = () => {
     event.preventDefault();
 
     try {
-      await mutation.mutateAsync({ email, message });
+      await mutation.mutateAsync({ email, message, company, token });
 
       toast({
         variant: 'success',
@@ -63,6 +74,10 @@ const EmailForm: FC = () => {
         className: 'font-medium',
       });
     } catch {
+      // token is single-use — reset so the user can retry
+      setToken('');
+      turnstileRef.current?.reset();
+
       toast({
         variant: 'error',
         description: t('form.error'),
@@ -103,9 +118,34 @@ const EmailForm: FC = () => {
           disabled={mutation.isPending}
         />
 
+        {/* Honeypot: hidden from real users, off-screen (not display:none) to catch more bots */}
+        <div aria-hidden="true" style={{ position: 'absolute', left: '-9999px', top: 'auto', width: '1px', height: '1px', overflow: 'hidden' }}>
+          <label htmlFor="company">Company</label>
+          <input
+            type="text"
+            name="company"
+            id="company"
+            tabIndex={-1}
+            autoComplete="off"
+            value={company}
+            onChange={e => setCompany(e.target.value)}
+          />
+        </div>
+
+        {siteKey && (
+          <Turnstile
+            ref={turnstileRef}
+            siteKey={siteKey}
+            options={{ theme: 'auto' }}
+            onSuccess={setToken}
+            onExpire={() => setToken('')}
+            onError={() => setToken('')}
+          />
+        )}
+
         <Button
           type="submit"
-          disabled={mutation.isPending}
+          disabled={mutation.isPending || (!!siteKey && !token)}
           className="w-full p-2 rounded bg-accent text-background hover:bg-secondary disabled:bg-gray-400"
         >
           {mutation.isPending ? t('form.sending') : t('form.send')}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@iconify/react": "^5.0.2",
+    "@marsidev/react-turnstile": "^1.5.3",
     "@mdx-js/loader": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
     "@next/mdx": "16.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@iconify/react':
         specifier: ^5.0.2
         version: 5.0.2(react@19.2.1)
+      '@marsidev/react-turnstile':
+        specifier: ^1.5.3
+        version: 1.5.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@mdx-js/loader':
         specifier: ^3.0.1
         version: 3.0.1(webpack@5.95.0)
@@ -505,6 +508,12 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@marsidev/react-turnstile@1.5.3':
+    resolution: {integrity: sha512-8Dij2jiNGNczq1U4EKpO4do2XepcTPxSMc2ZzvHndO+gcp68tvMULm27z2P99rGkdB89hc3452NZeu2Rti4g6A==}
+    peerDependencies:
+      react: ^17.0.2 || ^18.0.0 || ^19.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0
 
   '@mdx-js/loader@3.0.1':
     resolution: {integrity: sha512-YbYUt7YyEOdFxhyuCWmLKf5vKhID/hJAojEUnheJk4D8iYVLFQw+BAoBWru/dHGch1omtmZOPstsmKPyBF68Tw==}
@@ -4417,6 +4426,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@marsidev/react-turnstile@1.5.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
+    dependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
   '@mdx-js/loader@3.0.1(webpack@5.95.0)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
@@ -6088,7 +6102,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 7.0.1(eslint@8.57.1)
@@ -6122,7 +6136,7 @@ snapshots:
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
@@ -6151,7 +6165,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
Add two-layer, low-friction spam protection to the contact form:
- Honeypot "company" field (off-screen, silently dropped server-side)
- Cloudflare Turnstile (managed mode) verified via siteverify on the API route
- Basic input validation (require non-empty email/message)

Also documents setup in SPAM_PROTECTION.md and adds the @marsidev/react-turnstile dependency.