### PR TITLE
Hide Turnstile widget for legitimate visitors (interaction-only)

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -136,7 +136,7 @@ const EmailForm: FC = () => {
           <Turnstile
             ref={turnstileRef}
             siteKey={siteKey}
-            options={{ theme: 'auto' }}
+            options={{ theme: 'auto', appearance: 'interaction-only' }}
             onSuccess={setToken}
             onExpire={() => setToken('')}
             onError={() => setToken('')}


### PR DESCRIPTION
## What

Sets the Cloudflare Turnstile widget to `appearance: 'interaction-only'` so the widget box only renders when Cloudflare actually requires an interactive challenge. Normal visitors are verified silently in the background — no visible box — keeping the contact form clean.

Follow-up to the honeypot + Turnstile spam protection that was just merged.

## Why

In managed mode the widget rendered a persistent "Success!" box under the message field, which looked out of place on the contact form. `interaction-only` removes it for real users while keeping full managed protection (the box still appears for suspicious traffic that needs a challenge).

## Verification

- Loaded `/contact` locally with real Turnstile keys: no widget box renders, and the Send button still enables (token resolved silently in the background).
- The box only appears if Cloudflare escalates to an interactive challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)