### PR TITLE
fix: build the OpenAI client lazily and stop failing open on rate limits

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import OpenAI from 'openai';
 import fs from 'fs';
 import path from 'path';
-import { client, isRedisConfigured, withDeadline } from '@/lib/redis';
+import { anonymousId, client, isRedisConfigured, withDeadline } from '@/lib/redis';
 
 // Type definitions
 interface RequestBody {
@@ -24,6 +24,8 @@ interface ErrorResponse {
 interface RateLimitInfo {
   allowed: boolean;
   remaining: number;
+  /** Seconds until the caller's window resets. Only meaningful when denied. */
+  retryAfter: number;
 }
 
 interface OpenAIError {
@@ -37,12 +39,32 @@ interface OpenAIError {
 // Vercel max function duration in seconds (requires Pro plan for >10s)
 export const maxDuration = 30;
 
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+/**
+ * Built on first use, never at module scope: `next build` collects page data by
+ * importing route modules, and the SDK throws during construction when the key
+ * is missing. Constructing here would turn an unset variable into a failed
+ * build rather than a degraded endpoint. See the same pattern in lib/redis.ts.
+ *
+ * `undefined` means "not yet attempted"; `null` means "no usable key".
+ */
+let openai: OpenAI | null | undefined;
 
-// Build the system prompt once at module initialisation — avoids a
-// synchronous file read + string allocation on every request.
+function openaiClient(): OpenAI | null {
+  if (openai === undefined) {
+    const apiKey = process.env.OPENAI_API_KEY?.trim();
+
+    if (!apiKey) {
+      // Logged once rather than per request, so a misconfigured environment is
+      // visible without flooding the logs.
+      console.error('[chat] OPENAI_API_KEY is not set; the endpoint will report itself unavailable');
+    }
+
+    openai = apiKey ? new OpenAI({ apiKey }) : null;
+  }
+
+  return openai;
+}
+
 function buildSystemPrompt(): string {
   let knowledge = 'Knowledge base temporarily unavailable.';
   try {
@@ -68,50 +90,146 @@ ${knowledge}
 Remember: You represent William professionally, so maintain a helpful and engaging tone while staying focused on his career and technical expertise.`;
 }
 
-const SYSTEM_PROMPT = buildSystemPrompt();
+let systemPrompt: string | undefined;
 
-async function getRateLimitInfo(ip: string): Promise<RateLimitInfo> {
-  const limit = 10;
-  const windowSecs = 15 * 60;
-  const key = `ratelimit:${ip}`;
+/**
+ * Built once per instance — a synchronous file read and a large string
+ * allocation on every request would be wasteful — but on first use rather than
+ * at import, so the read doesn't run during `next build`.
+ */
+function getSystemPrompt(): string {
+  if (systemPrompt === undefined) systemPrompt = buildSystemPrompt();
+  return systemPrompt;
+}
 
+const LIMIT = 10;
+const WINDOW_SECS = 15 * 60;
+
+/**
+ * Per-instance fallback for when the shared store can't answer. Fluid Compute
+ * reuses instances, so this still throttles meaningfully; it resets on a cold
+ * start and isn't shared between instances, which is why it's a fallback and
+ * not the primary limiter.
+ *
+ * The alternative — allowing the request, as this route used to — left the
+ * endpoint calling OpenAI unmetered whenever the store was unreachable, which
+ * it silently was for a while.
+ */
+const localHits = new Map<string, { count: number; resetAt: number }>();
+
+/** Bound on `localHits`, so a flood of distinct callers can't grow it forever. */
+const MAX_LOCAL_KEYS = 5000;
+
+function pruneLocalHits(now: number): void {
+  for (const [key, entry] of localHits) {
+    if (entry.resetAt <= now) localHits.delete(key);
+  }
+
+  // Still over budget means the window is genuinely full of live entries. Drop
+  // the least recently created rather than letting the map grow without bound.
+  const excess = localHits.size - MAX_LOCAL_KEYS;
+  if (excess > 0) {
+    for (const key of [...localHits.keys()].slice(0, excess)) localHits.delete(key);
+  }
+}
+
+function localRateLimit(id: string): RateLimitInfo {
+  const now = Date.now();
+  const existing = localHits.get(id);
+  const entry = existing && existing.resetAt > now ? existing : { count: 0, resetAt: now + WINDOW_SECS * 1000 };
+
+  entry.count += 1;
+  localHits.set(id, entry);
+
+  if (localHits.size > MAX_LOCAL_KEYS) pruneLocalHits(now);
+
+  return {
+    allowed: entry.count <= LIMIT,
+    remaining: Math.max(0, LIMIT - entry.count),
+    retryAfter: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+  };
+}
+
+async function redisRateLimit(id: string): Promise<RateLimitInfo> {
+  const key = `ratelimit:${id}`;
+
+  const count = await withDeadline('rate limit', client().incr(key));
+  if (count === 1) await withDeadline('rate limit', client().expire(key, WINDOW_SECS));
+
+  if (count <= LIMIT) return { allowed: true, remaining: LIMIT - count, retryAfter: 0 };
+
+  // Only on the deny path: an accurate Retry-After is worth one extra round
+  // trip for a caller who is already being turned away, and denials are rare.
+  let retryAfter = WINDOW_SECS;
+  try {
+    const ttl = await withDeadline('rate limit ttl', client().ttl(key));
+    if (typeof ttl === 'number' && ttl > 0) retryAfter = ttl;
+  } catch (error) {
+    console.error('[chat] could not read the rate limit TTL, reporting the full window:', error);
+  }
+
+  return { allowed: false, remaining: 0, retryAfter };
+}
+
+let warnedAboutStore = false;
+
+/**
+ * Throttles on the shared store when it can answer, and on the per-instance
+ * limiter when it can't. Never allows an unmetered request: this endpoint calls
+ * OpenAI, so "fail open" is a billing decision, not just an availability one.
+ */
+async function getRateLimitInfo(id: string): Promise<RateLimitInfo> {
   if (!isRedisConfigured) {
-    console.error('Rate limit store not configured, allowing request');
-    return { allowed: true, remaining: 1 };
+    if (!warnedAboutStore) {
+      warnedAboutStore = true;
+      console.error('[chat] rate limit store is not configured; using the per-instance limiter');
+    }
+    return localRateLimit(id);
   }
 
   try {
-    const count = await withDeadline('rate limit', client().incr(key));
-    if (count === 1) await withDeadline('rate limit', client().expire(key, windowSecs));
-    if (count > limit) return { allowed: false, remaining: 0 };
-    return { allowed: true, remaining: limit - count };
+    return await redisRateLimit(id);
   } catch (error) {
-    // Fails open so an outage doesn't take the chat down — but that means an
-    // unreachable store leaves this endpoint unthrottled, so make it loud.
-    console.error('Rate limit store error, allowing request:', error);
-    return { allowed: true, remaining: 1 };
+    // Loud on every occurrence: the fallback keeps chat working, and that must
+    // not make a dead store look healthy.
+    console.error('[chat] rate limit store unavailable, using the per-instance limiter:', error);
+    return localRateLimit(id);
   }
+}
+
+function rateLimitHeaders(info: RateLimitInfo): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(LIMIT),
+    'X-RateLimit-Remaining': String(info.remaining),
+  };
+}
+
+/**
+ * Best-effort client address. Vercel sets x-forwarded-for; the fallback keeps
+ * local development working, where every request looks like the same caller.
+ */
+function clientIp(request: NextRequest): string {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0].trim();
+
+  return request.headers.get('x-real-ip')?.trim() || 'unknown';
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse<ChatResponse | ErrorResponse>> {
   try {
-    // Get client IP for rate limiting
-    const ip =
-      request.headers.get('x-real-ip') ||
-      request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-      'unknown';
+    let body: unknown;
 
-    // Check rate limit
-    const rateLimit = await getRateLimitInfo(ip);
-    if (!rateLimit.allowed) {
-      return NextResponse.json({ error: 'Too many requests. Please try again in 15 minutes.' }, { status: 429 });
+    try {
+      body = await request.json();
+    } catch {
+      return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 });
     }
 
-    // Parse request body
-    const body = (await request.json()) as RequestBody;
-    const { message } = body;
+    const { message } = (body ?? {}) as Partial<RequestBody>;
 
-    // Validate input
+    // Validated before the rate limit is touched, so a malformed body doesn't
+    // burn one of the caller's requests. Nothing billable is reachable from
+    // here — these paths call neither the store nor OpenAI.
     if (!message || typeof message !== 'string' || message.trim().length === 0) {
       return NextResponse.json({ error: 'Message is required and must be a non-empty string' }, { status: 400 });
     }
@@ -120,17 +238,33 @@ export async function POST(request: NextRequest): Promise<NextResponse<ChatRespo
       return NextResponse.json({ error: 'Message too long. Please keep it under 500 characters.' }, { status: 400 });
     }
 
-    // Check if OpenAI API key is configured
-    if (!process.env.OPENAI_API_KEY) {
-      console.error('OpenAI API key not found');
+    // Checked before the rate limit for the same reason: an unconfigured
+    // endpoint can't spend anything, so it shouldn't spend the caller's quota.
+    const ai = openaiClient();
+    if (!ai) {
       return NextResponse.json({ error: 'AI service is not configured. Please try again later.' }, { status: 503 });
     }
 
+    // The raw address is never stored or logged — only a salted digest, the
+    // same treatment article likes give it (see lib/likes-store.ts).
+    const id = await anonymousId('chat', clientIp(request));
+    const rateLimit = await getRateLimitInfo(id);
+
+    if (!rateLimit.allowed) {
+      return NextResponse.json(
+        { error: 'Too many requests. Please try again in 15 minutes.' },
+        {
+          status: 429,
+          headers: { ...rateLimitHeaders(rateLimit), 'Retry-After': String(rateLimit.retryAfter) },
+        }
+      );
+    }
+
     // Call OpenAI API
-    const completion = await openai.chat.completions.create({
+    const completion = await ai.chat.completions.create({
       model: 'gpt-4o-mini',
       messages: [
-        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'system', content: getSystemPrompt() },
         { role: 'user', content: message.trim() },
       ],
       max_tokens: 300,
@@ -139,19 +273,25 @@ export async function POST(request: NextRequest): Promise<NextResponse<ChatRespo
       frequency_penalty: 0.1,
     });
 
-    const response = completion.choices[0].message.content;
+    const response = completion.choices[0]?.message?.content;
     const tokensUsed = completion.usage?.total_tokens || 0;
 
-    // Log for monitoring
-    console.log(`Chat request - IP: ${ip}, Tokens: ${tokensUsed}, Message length: ${message.length}`);
+    // Logged at warn, not log: `removeConsole` in next.config.mjs strips
+    // console.log from production builds, so this monitoring line was compiled
+    // out of the only environment anyone reads it in. `warn` and `error` are
+    // the levels that survive.
+    console.warn(`[chat] request from ${id} - tokens: ${tokensUsed}, message length: ${message.length}`);
 
-    return NextResponse.json({
-      response: response || 'Sorry, I could not generate a response. Please try again.',
-      tokensUsed,
-      rateLimit: {
-        remaining: rateLimit.remaining,
+    return NextResponse.json(
+      {
+        response: response || 'Sorry, I could not generate a response. Please try again.',
+        tokensUsed,
+        rateLimit: {
+          remaining: rateLimit.remaining,
+        },
       },
-    });
+      { headers: rateLimitHeaders(rateLimit) }
+    );
   } catch (error) {
     console.error('Chat API error:', error);
 


### PR DESCRIPTION
Two latent defects in `/api/chat`, found while fixing the blog like counter in #57. Both confirmed reproducible before fixing.

## 1. The OpenAI client was built at module scope

`next build` collects page data by importing route modules, and the SDK throws during construction when the key is absent. Any environment missing `OPENAI_API_KEY` failed the **build** rather than degrading the endpoint:

```
Error: The OPENAI_API_KEY environment variable is missing or empty…
> Build error occurred
Error: Failed to collect page data for /api/chat
```

Not breaking deploys today only because the key happens to be set in every Vercel environment.

Now built on first use and cached, matching the `buildClient()` / `client()` pattern in `lib/redis.ts`. Two consequences:

- The existing `if (!process.env.OPENAI_API_KEY)` → 503 guard was **dead code** — the module could never load without the key. It's now reachable.
- `SYSTEM_PROMPT` moved to first-use too; its `readFileSync` was also running at build time.

## 2. Rate limiting failed open

`getRateLimitInfo()` returned `allowed: true` whenever the store was unreachable *or* unconfigured. This endpoint calls OpenAI, so failing open is a billing decision, not just an availability one — and it silently sat in that state while pointed at a deleted Upstash database.

It now falls back to a per-instance in-memory limiter (same 10 / 15 min) instead of allowing the request. An outage no longer means unmetered OpenAI calls, and a Redis blip no longer takes chat offline. The fallback logs loudly on every occurrence so a dead store can't look healthy.

**Tradeoffs, explicitly:** the fallback is per-instance and resets on cold start, so during an outage the effective ceiling is 10 × live instances. And where the store *hangs* rather than refusing, each request waits out `lib/redis.ts`'s 5s deadline before falling back.

## Also in this PR

- **Hashed caller ids.** Keys on `anonymousId('chat', ip)` (reused from `lib/redis.ts`) rather than `ratelimit:${rawIp}`, matching how article likes treat addresses. The raw IP is no longer stored or logged.
- **The monitoring log line never worked in production.** `removeConsole` in `next.config.mjs` strips `console.log` from production builds, excluding only `error`/`warn` — so the per-request token-usage line was compiled out of the only environment anyone reads it in. Moved to `console.warn`. *This is a real change in production log volume* (one line per successful chat request; the 10/15min cap keeps it low). Easy to revert if unwanted.
- **Validate before consuming quota**, so a malformed body no longer burns one of the caller's ten. Bad JSON now returns 400 rather than falling through to a misleading 500.
- `X-RateLimit-Limit` / `X-RateLimit-Remaining` on success, plus `Retry-After` on 429 (read from the key's real TTL, fetched only on the deny path).

Response body shape is unchanged, so `components/chat-widget/hooks/useChatMessages.ts` needs no update.

## Verification

Tested against a **production build** (`next build` + `next start`), not `next dev` — a production-only bug went unnoticed in dev last time. Nothing touched a real database or spent OpenAI credits: a throwaway mock served the Upstash REST protocol (in-memory `Map` answering `INCR`/`EXPIRE`/`TTL`) and a stub `/v1/chat/completions` via `OPENAI_BASE_URL`.

| Check | Before | After |
|---|---|---|
| `next build` with no `OPENAI_API_KEY` | ❌ fails to collect page data | ✅ builds |
| POST with no key | unreachable (build failed) | ✅ 503, guard logs once |
| Store reachable, 12 requests | 10 OK → 429 | ✅ 10 OK → 429, `Retry-After: 900` from real TTL |
| Store killed mid-run, 12 requests | ❌ 12 unmetered OpenAI calls | ✅ 10 OK → 429 (`Retry-After: 899`), logged each time |
| Store unconfigured, 12 requests | ❌ 12 unmetered OpenAI calls | ✅ 10 OK → 429, warning logged once |
| Raw IP in store keys or logs | ❌ `ratelimit:203.0.113.45` | ✅ `ratelimit:ac0d9bc707999647`, 0 hits for the IP |
| `{}` / 600-char / non-JSON body | 400/400/**500**, quota consumed | ✅ 400/400/400, quota untouched |

`tsc --noEmit` is clean. `pnpm lint` fails, but that's pre-existing and unrelated — an eslint 8 / `.eslintrc.json` vs eslint-config-next 16 flat-config mismatch that errors during config load; confirmed by linting an untouched file with this change stashed.

## Not covered

Nothing here was verified against a real Upstash store. The preview 503 on the like counter is still open — worth confirming `UPSTASH_REDIS_REST_URL` is the `https://` REST endpoint from the console (not the `redis://` string, not `KV_URL`) before assuming chat behaves differently there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
