### PR TITLE
content: refresh knowledge base and site copy for the Disney AI platform work

### DIFF
--- a/components/AboutMe.tsx
+++ b/components/AboutMe.tsx
@@ -26,7 +26,7 @@ const AboutMe = () => {
           <small className="text-xl mb-1 font-medium text-secondary block">{t('greeting.hello')}</small>
           <h1 className="text-6xl sm:text-7xl font-bold text-primary mb-2">William Craig!</h1>
           <h2 className="text-3xl sm:text-4xl mb-2">{t('greeting.role')}</h2>
-          <p className="text-2xl font-bold mb-2 text-secondary">Fullstack, Frontend, UX</p>
+          <p className="text-2xl font-bold mb-2 text-secondary">{t('greeting.tagline')}</p>
           <p className=" text-primary text-2xl font-medium">{t('greeting.title')}</p>
         </section>
 

--- a/components/TechStack.tsx
+++ b/components/TechStack.tsx
@@ -3,34 +3,56 @@
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { useState } from 'react';
-import { CodeXml, Server, Palette, Cloud, MonitorSpeaker, Layers, LucideIcon, Lightbulb } from 'lucide-react';
+import { CodeXml, Server, Palette, Cloud, MonitorSpeaker, Layers, LucideIcon, Lightbulb, Sparkles } from 'lucide-react';
 
-// Technology data organized by categories
+// Technology data organized by categories. Order here is the order rendered:
+// AI first, then the architecture and infrastructure work, with the UI layers
+// after it — matching where the day-to-day work actually sits now.
 const technologyData = {
+  ai: {
+    icon: Sparkles,
+    color: 'text-orange-500 dark:text-orange-400',
+    lineColor: 'bg-orange-500',
+    technologies: [
+      'AI',
+      'LLM Orchestration',
+      'LLM Observability',
+      'RAG',
+      'Agentic Workflows',
+      'MCP',
+      'LiteLLM',
+      'Prompt Engineering',
+    ],
+    yearsKey: 'years.threePlus',
+  },
   fullstack: {
     icon: Layers,
     color: 'text-green-500 dark:text-green-400',
     lineColor: 'bg-green-500',
     technologies: [
-      'AI',
-      'LLM Orchestration',
       'System Design',
-      'Next.js',
-      'Performance',
-      'Security',
       'Scalability',
+      'Security',
+      'Performance',
       'Logging',
+      'Testing',
       'Coaching',
       'Mentoring',
-      'Testing',
     ],
+    yearsKey: 'years.tenPlus',
+  },
+  devops: {
+    icon: Cloud,
+    color: 'text-indigo-500 dark:text-indigo-400',
+    lineColor: 'bg-indigo-500',
+    technologies: ['AWS', 'Terraform', 'Datadog', 'Docker', 'CI/CD', 'Vercel', 'Git', 'Monitoring', 'Infrastructure as Code', 'Auto Scaling'],
     yearsKey: 'years.fivePlus',
   },
   frontend: {
     icon: CodeXml,
     color: 'text-blue-600 dark:text-blue-400',
     lineColor: 'bg-blue-600',
-    technologies: ['React', 'TypeScript', 'Tailwind', 'Bundling', 'TansTack Query', 'HTML / CSS', 'Angular', 'State Management'],
+    technologies: ['React', 'TypeScript', 'Next.js', 'Tailwind', 'Bundling', 'TansTack Query', 'HTML / CSS', 'Angular', 'State Management'],
     yearsKey: 'years.fifteenPlus',
   },
   design: {
@@ -39,13 +61,6 @@ const technologyData = {
     lineColor: 'bg-pink-500',
     technologies: ['Figma', 'Adobe XD', 'Photoshop', 'A11y', 'UI Design Library', 'High-Fi Mockups', 'Brand', 'Usability'],
     yearsKey: 'years.tenPlus',
-  },
-  devops: {
-    icon: Cloud,
-    color: 'text-indigo-500 dark:text-indigo-400',
-    lineColor: 'bg-indigo-500',
-    technologies: ['Vercel', 'AWS', 'Terraform', 'Datadog', 'Docker', 'Git', 'CI/CD', 'Monitoring', 'Infrastructure as Code', 'Auto Scaling'],
-    yearsKey: 'years.threePlus',
   },
   mobile: {
     icon: MonitorSpeaker,
@@ -66,7 +81,13 @@ const technologyData = {
 // Enhanced technology data with learning info
 const detailedTechData: { [key: string]: { learned: string; projects: string[] } } = {
   AI: { learned: '2023', projects: ['Disney', 'SQOR.ai', 'Chatbots', 'AI Tools'] },
-  'LLM Orchestration': { learned: '2025', projects: ['Disney', 'SQOR.ai', 'Multi-Model Routing', 'RAG'] },
+  'LLM Orchestration': { learned: '2025', projects: ['Disney', 'SQOR.ai', 'Multi-Model Routing', 'Fallbacks'] },
+  'LLM Observability': { learned: '2025', projects: ['Disney', 'Token & Cost Tracking', 'Latency Monitoring', 'Alerting'] },
+  RAG: { learned: '2024', projects: ['Disney', 'Knowledge Retrieval', 'Grounded Answers'] },
+  'Agentic Workflows': { learned: '2024', projects: ['Disney', 'Felix', 'Multi-Agent Support Tools'] },
+  MCP: { learned: '2025', projects: ['Disney', 'Felix', 'Datadog / Jira / GitHub Integrations'] },
+  LiteLLM: { learned: '2025', projects: ['Disney', 'Multi-Provider Gateway', 'Usage Instrumentation'] },
+  'Prompt Engineering': { learned: '2023', projects: ['Disney', 'SQOR.ai', 'Craigraphics Chatbot'] },
   'System Design': { learned: '2017', projects: ['Scalable Architectures', 'High-Traffic Apps', 'Enterprise Solutions'] },
   Performance: { learned: '2012', projects: ['Optimization Projects', 'Speed Improvements', 'Web Vitals'] },
   Scalability: { learned: '2016', projects: ['High-Load Systems', 'Microservices', 'Cloud Architecture'] },
@@ -238,6 +259,15 @@ const TechStack = () => {
 
   const categories = [
     {
+      key: 'ai',
+      IconComponent: technologyData.ai.icon,
+      iconColor: technologyData.ai.color,
+      lineColor: technologyData.ai.lineColor,
+      technologies: technologyData.ai.technologies,
+      yearsKey: technologyData.ai.yearsKey,
+      title: tToolbox('ai.title'),
+    },
+    {
       key: 'fullstack',
       IconComponent: technologyData.fullstack.icon,
       iconColor: technologyData.fullstack.color,
@@ -247,15 +277,14 @@ const TechStack = () => {
       title: tToolbox('fullstack.title'),
     },
     {
-      key: 'frontend',
-      IconComponent: technologyData.frontend.icon,
-      iconColor: technologyData.frontend.color,
-      lineColor: technologyData.frontend.lineColor,
-      technologies: technologyData.frontend.technologies,
-      yearsKey: technologyData.frontend.yearsKey,
-      title: t('toolbox.frontend.title'),
+      key: 'devops',
+      IconComponent: technologyData.devops.icon,
+      iconColor: technologyData.devops.color,
+      lineColor: technologyData.devops.lineColor,
+      technologies: technologyData.devops.technologies,
+      yearsKey: technologyData.devops.yearsKey,
+      title: t('toolbox.devops.title'),
     },
-
     {
       key: 'backend',
       IconComponent: technologyData.backend.icon,
@@ -266,6 +295,15 @@ const TechStack = () => {
       title: t('toolbox.backend.title'),
     },
     {
+      key: 'frontend',
+      IconComponent: technologyData.frontend.icon,
+      iconColor: technologyData.frontend.color,
+      lineColor: technologyData.frontend.lineColor,
+      technologies: technologyData.frontend.technologies,
+      yearsKey: technologyData.frontend.yearsKey,
+      title: t('toolbox.frontend.title'),
+    },
+    {
       key: 'design',
       IconComponent: technologyData.design.icon,
       iconColor: technologyData.design.color,
@@ -273,15 +311,6 @@ const TechStack = () => {
       technologies: technologyData.design.technologies,
       yearsKey: technologyData.design.yearsKey,
       title: t('toolbox.design.title'),
-    },
-    {
-      key: 'devops',
-      IconComponent: technologyData.devops.icon,
-      iconColor: technologyData.devops.color,
-      lineColor: technologyData.devops.lineColor,
-      technologies: technologyData.devops.technologies,
-      yearsKey: technologyData.devops.yearsKey,
-      title: t('toolbox.devops.title'),
     },
     {
       key: 'mobile',

--- a/components/TechStack.tsx
+++ b/components/TechStack.tsx
@@ -13,6 +13,7 @@ const technologyData = {
     lineColor: 'bg-green-500',
     technologies: [
       'AI',
+      'LLM Orchestration',
       'System Design',
       'Next.js',
       'Performance',
@@ -43,7 +44,7 @@ const technologyData = {
     icon: Cloud,
     color: 'text-indigo-500 dark:text-indigo-400',
     lineColor: 'bg-indigo-500',
-    technologies: ['Vercel', 'AWS', 'Docker', 'Git', 'CI/CD', 'Monitoring', 'Infrastructure as Code', 'Auto Scaling'],
+    technologies: ['Vercel', 'AWS', 'Terraform', 'Datadog', 'Docker', 'Git', 'CI/CD', 'Monitoring', 'Infrastructure as Code', 'Auto Scaling'],
     yearsKey: 'years.threePlus',
   },
   mobile: {
@@ -64,7 +65,8 @@ const technologyData = {
 
 // Enhanced technology data with learning info
 const detailedTechData: { [key: string]: { learned: string; projects: string[] } } = {
-  AI: { learned: '2023', projects: ['Chatbots', 'AI Tools', 'Machine Learning'] },
+  AI: { learned: '2023', projects: ['Disney', 'SQOR.ai', 'Chatbots', 'AI Tools'] },
+  'LLM Orchestration': { learned: '2025', projects: ['Disney', 'SQOR.ai', 'Multi-Model Routing', 'RAG'] },
   'System Design': { learned: '2017', projects: ['Scalable Architectures', 'High-Traffic Apps', 'Enterprise Solutions'] },
   Performance: { learned: '2012', projects: ['Optimization Projects', 'Speed Improvements', 'Web Vitals'] },
   Scalability: { learned: '2016', projects: ['High-Load Systems', 'Microservices', 'Cloud Architecture'] },
@@ -73,9 +75,9 @@ const detailedTechData: { [key: string]: { learned: string; projects: string[] }
   Coaching: { learned: '2019', projects: ['Team Leadership', 'Junior Developer Mentoring', 'Code Reviews'] },
   Mentoring: { learned: '2020', projects: ['Career Guidance', 'Technical Mentorship', 'Knowledge Transfer'] },
   Testing: { learned: '2015', projects: ['Unit Tests', 'Integration Tests', 'E2E Testing'] },
-  React: { learned: '2018', projects: ['Autodesk', 'Frontier Communications', 'Craigraphics LLC'] },
-  'Next.js': { learned: '2020', projects: ['Craigraphics LLC', 'Autodesk', 'Business Website'] },
-  TypeScript: { learned: '2020', projects: ['Autodesk', 'Craigraphics LLC'] },
+  React: { learned: '2018', projects: ['Disney', 'Autodesk', 'Frontier Communications', 'Craigraphics LLC'] },
+  'Next.js': { learned: '2020', projects: ['Disney', 'Craigraphics LLC', 'Autodesk', 'Business Website'] },
+  TypeScript: { learned: '2020', projects: ['Disney', 'Autodesk', 'Craigraphics LLC'] },
   Tailwind: { learned: '2021', projects: ['Autodesk', 'Craigraphics LLC'] },
   Bundling: { learned: '2021', projects: ['Webpack', 'Vite', 'Build Optimization'] },
   'TansTack Query': { learned: '2023', projects: ['Craigraphics LLC'] },
@@ -84,7 +86,7 @@ const detailedTechData: { [key: string]: { learned: string; projects: string[] }
   Angular: { learned: '2015', projects: ['Carnival Cruise v1', 'Personal projects'] },
   'Node.js': { learned: '2015', projects: ['API Development', 'Server Applications'] },
   Express: { learned: '2015', projects: ['REST APIs', 'Backend Services'] },
-  Python: { learned: '2023', projects: ['Data Processing', 'Automation Scripts'] },
+  Python: { learned: '2023', projects: ['Disney', 'Data Processing', 'Automation Scripts'] },
   REST: { learned: '2013', projects: ['API Integrations', 'Microservices'] },
   PostgreSQL: { learned: '2016', projects: ['Relational Databases', 'Complex Queries'] },
   MongoDB: { learned: '2016', projects: ['Document Stores', 'NoSQL Apps'] },
@@ -105,6 +107,8 @@ const detailedTechData: { [key: string]: { learned: string; projects: string[] }
   Git: { learned: '2011', projects: ['Version Control', 'Team Collaboration'] },
   'CI/CD': { learned: '2016', projects: ['Automated Pipelines', 'Continuous Deployment', 'GitHub Actions'] },
   Monitoring: { learned: '2018', projects: ['Application Performance', 'Error Tracking', 'Uptime Monitoring'] },
+  Terraform: { learned: '2025', projects: ['Disney', 'Infrastructure Provisioning', 'AI Platform Services'] },
+  Datadog: { learned: '2025', projects: ['Disney', 'LLM Observability', 'APM & Monitors', 'Alerting'] },
   'Infrastructure as Code': { learned: '2019', projects: ['Terraform Scripts', 'CloudFormation', 'Automated Provisioning'] },
   'Auto Scaling': { learned: '2019', projects: ['Load Balancing', 'Traffic Management', 'Cost Optimization'] },
   'React Native': { learned: '2022', projects: ['Mobile Apps', 'Cross-Platform'] },

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,7 +20,7 @@
     },
 
     "title": "About Me",
-    "intro": "I'm a code enthusiast with 15+ years of turning coffee into high-performance web applications. I don't have superpowers, but I love creating smooth user experiences like water. I've had the privilege of working with some pretty cool brands like Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidency of Mexico and Coca-Cola.",
+    "intro": "I'm a code enthusiast with 15+ years of turning coffee into software. These days I work on AI platform infrastructure at Disney, orchestrating multiple LLMs and building the observability behind a self-service assistant used by millions of subscribers. I don't have superpowers, but I love creating smooth user experiences like water. I've had the privilege of working with some pretty cool brands like Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidency of Mexico and Coca-Cola.",
     "whatIDo": "What I Do",
     "skills": {
       "fullStack": "<em>Full-stack</em> with a focus on Front-end.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,22 +16,26 @@
     "greeting": {
       "hello": "Hey there, I'm",
       "role": "Senior Software Engineer",
+      "tagline": "AI Platforms, Architecture, UX",
       "title": "Passionate about creating amazing web experiences."
     },
 
     "title": "About Me",
-    "intro": "I'm a code enthusiast with 15+ years of turning coffee into software. These days I work on AI platform infrastructure at Disney, orchestrating multiple LLMs and building the observability behind a self-service assistant used by millions of subscribers. I don't have superpowers, but I love creating smooth user experiences like water. I've had the privilege of working with some pretty cool brands like Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidency of Mexico and Coca-Cola.",
+    "intro": "I'm a code enthusiast with 15+ years of turning coffee into software. These days I work on AI platform infrastructure at Disney, orchestrating multiple LLMs and building the observability behind a self-service assistant used by millions of subscribers. I've had the privilege of working with some pretty cool brands like Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidency of Mexico and Coca-Cola.",
     "whatIDo": "What I Do",
     "skills": {
-      "fullStack": "<em>Full-stack</em> with a focus on Front-end.",
-      "design": "Turn <em>designer</em> and product ideas into fully functional applications with a big eye on design.",
+      "fullStack": "Build <em>AI platforms</em> end to end, from LLM orchestration and observability down to the interface.",
+      "design": "Bring a <em>designer's eye</em> to product and architecture decisions, turning ambitious ideas into systems people enjoy using.",
       "performance": "Make fast <em>performant</em> websites with heavy traffic.",
       "problemSolving": "Solve <em>complex</em> problems and <em>lead</em> small <em>teams</em>."
     },
-    "myToolbox": "Tech Stack & Expertise",
+    "myToolbox": "Engineering Toolbox",
     "toolbox": {
+      "ai": {
+        "title": "AI & LLM"
+      },
       "fullstack": {
-        "title": "Full Stack"
+        "title": "Architecture & Practice"
       },
       "description": "The tools and technologies I use to build exceptional digital experiences",
       "since": "Since",
@@ -64,7 +68,7 @@
         "tools": ["Figma", "Adobe XD", "Responsive Design", "UI/UX Principles", "Graphic Design"]
       },
       "devops": {
-        "title": "DevOps",
+        "title": "Cloud & DevOps",
         "tools": ["Docker", "Jenkins", "CI/CD", "GIT", "Netlify", "Vercel", "AWS"]
       },
       "build": {
@@ -82,8 +86,8 @@
     },
     "funFacts": {
       "title": "Fun Facts",
-      "languages": "Fluent in English, Spanish, and JavaScript.",
-      "power": "Powered by code, coffee and music.",
+      "languages": "Fluent in English, Spanish, and TypeScript.",
+      "power": "Powered by AI, code, coffee and music.",
       "music": "Debugging soundtrack: Ambient music and John Coltrane.",
       "hobby": "When not coding, you'll find me playing table tennis."
     },

--- a/messages/es.json
+++ b/messages/es.json
@@ -19,7 +19,7 @@
       "title": "Apasionado por crear experiencias web increíbles."
     },
     "title": "Sobre Mí",
-    "intro": "Soy un entusiasta del código con más de 15 años de experiencia convirtiendo café en aplicaciones web de alto rendimiento. No tengo superpoderes, pero me encanta crear experiencias de usuario fluidas como el agua. He tenido el privilegio de trabajar con marcas geniales como Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidencia de México y Coca-Cola.",
+    "intro": "Soy un entusiasta del código con más de 15 años de experiencia convirtiendo café en software. Actualmente trabajo en infraestructura de plataformas de IA en Disney, orquestando múltiples LLMs y construyendo la observabilidad detrás de un asistente de autoservicio que usan millones de suscriptores. No tengo superpoderes, pero me encanta crear experiencias de usuario fluidas como el agua. He tenido el privilegio de trabajar con marcas geniales como Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidencia de México y Coca-Cola.",
     "whatIDo": "Lo Que Hago",
     "skills": {
       "fullStack": "Desarrollo full-stack con enfoque en front-end.",

--- a/messages/es.json
+++ b/messages/es.json
@@ -16,21 +16,25 @@
     "greeting": {
       "hello": "Hola, Soy",
       "role": "Ingeniero de Software Senior",
+      "tagline": "Plataformas de IA, Arquitectura, UX",
       "title": "Apasionado por crear experiencias web increíbles."
     },
     "title": "Sobre Mí",
-    "intro": "Soy un entusiasta del código con más de 15 años de experiencia convirtiendo café en software. Actualmente trabajo en infraestructura de plataformas de IA en Disney, orquestando múltiples LLMs y construyendo la observabilidad detrás de un asistente de autoservicio que usan millones de suscriptores. No tengo superpoderes, pero me encanta crear experiencias de usuario fluidas como el agua. He tenido el privilegio de trabajar con marcas geniales como Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidencia de México y Coca-Cola.",
+    "intro": "Soy un entusiasta del código con más de 15 años de experiencia convirtiendo café en software. Actualmente trabajo en infraestructura de plataformas de IA en Disney, orquestando múltiples LLMs y construyendo la observabilidad detrás de un asistente de autoservicio que usan millones de suscriptores. He tenido el privilegio de trabajar con marcas geniales como Disney, Autodesk, General Motors, Frontier, Carnival Cruise, Telmex, Presidencia de México y Coca-Cola.",
     "whatIDo": "Lo Que Hago",
     "skills": {
-      "fullStack": "Desarrollo full-stack con enfoque en front-end.",
-      "design": "Convierto ideas de diseñadores y productos en aplicaciones completamente funcionales con gran atención al diseño.",
-      "performance": "Creo sitios web rápidos y de alto rendimiento con tráfico pesado.",
-      "problemSolving": "Resuelvo problemas complejos y lidero equipos pequeños."
+      "fullStack": "Construyo <em>plataformas de IA</em> de extremo a extremo, desde la orquestación de LLMs y la observabilidad hasta la interfaz.",
+      "design": "Aporto una <em>mirada de diseñador</em> a las decisiones de producto y arquitectura, convirtiendo ideas ambiciosas en sistemas que da gusto usar.",
+      "performance": "Creo sitios web <em>rápidos</em> y de alto rendimiento con tráfico pesado.",
+      "problemSolving": "Resuelvo problemas <em>complejos</em> y <em>lidero equipos</em> pequeños."
     },
-    "myToolbox": "Stack Tecnológico y Experiencia",
+    "myToolbox": "Caja de Herramientas",
     "toolbox": {
+      "ai": {
+        "title": "IA y LLM"
+      },
       "fullstack": {
-        "title": "Full Stack"
+        "title": "Arquitectura y Práctica"
       },
       "description": "Las herramientas y tecnologías que uso para crear experiencias digitales excepcionales",
       "since": "Desde",
@@ -63,7 +67,7 @@
         "tools": ["Figma", "Adobe XD", "Diseño Responsivo", "Principios de UI/UX", "Diseño Gráfico"]
       },
       "devops": {
-        "title": "DevOps",
+        "title": "Cloud y DevOps",
         "tools": ["Docker", "Jenkins", "CI/CD", "GIT", "Netlify", "Vercel", "AWS"]
       },
       "build": {
@@ -81,8 +85,8 @@
     },
     "funFacts": {
       "title": "Datos Curiosos",
-      "languages": "Fluido en inglés, español y JavaScript.",
-      "power": "Impulsado por código, café y música.",
+      "languages": "Fluido en inglés, español y TypeScript.",
+      "power": "Impulsado por IA, código, café y música.",
       "music": "Banda sonora para depurar: Música ambiental y John Coltrane.",
       "hobby": "Cuando no estoy programando, me encontrarás jugando tenis de mesa."
     },

--- a/william-craig-knowledge.md
+++ b/william-craig-knowledge.md
@@ -8,11 +8,11 @@
 **Work Preferences:** Open to remote (anywhere), hybrid, or onsite positions  
 **Geographic Availability:** Onsite/Hybrid in San Francisco Bay Area and Sacramento  
 **Years of Experience:** 15+ years  
-**Languages:** Fluent in English, Spanish, and JavaScript  
+**Languages:** Fluent in English, Spanish, and TypeScript  
 **Certification:** Certified Professional for Software Architecture — Foundation Level (CPSA-F), iSAQB, April 2026  
 **Linkedin** https://www.linkedin.com/in/willcraigz/  
 **Contact:** craigraphics@gmail.com  
-**Personal Interests:** Table tennis, ambient music, John Coltrane, powered by code, coffee and music
+**Personal Interests:** Table tennis, ambient music, John Coltrane, powered by AI, code, coffee and music
 
 ## Professional Summary
 
@@ -236,4 +236,4 @@ Today I work on the infrastructure that makes LLM-powered products reliable: mul
 - I enjoy reading about philosophy, astronomy, particle physics, General Relativity, history and social psychology.
 - I am engaged with a beautiful woman and I am very fortunate man.
 
-**Current Professional Motto:** "Powered by code, coffee and music" - Combining technical expertise with creative problem-solving, focusing on creating seamless user experiences while maintaining high performance and scalability standards.
+**Current Professional Motto:** "Powered by AI, code, coffee and music" - Combining technical expertise with creative problem-solving, focusing on creating seamless user experiences while maintaining high performance and scalability standards.

--- a/william-craig-knowledge.md
+++ b/william-craig-knowledge.md
@@ -3,48 +3,102 @@
 ## Personal Information
 
 **Name:** William Craig  
-**Current Role:** Senior Software Engineer & Full Stack Developer  
+**Current Role:** Senior Software Engineer (AI Platform & Full Stack) at Disney  
 **Location:** Benicia, CA (San Francisco Bay Area)  
 **Work Preferences:** Open to remote (anywhere), hybrid, or onsite positions  
 **Geographic Availability:** Onsite/Hybrid in San Francisco Bay Area and Sacramento  
 **Years of Experience:** 15+ years  
 **Languages:** Fluent in English, Spanish, and JavaScript  
-**Linkedin** https://www.linkedin.com/in/willcraigz/
+**Certification:** Certified Professional for Software Architecture — Foundation Level (CPSA-F), iSAQB, April 2026  
+**Linkedin** https://www.linkedin.com/in/willcraigz/  
+**Contact:** craigraphics@gmail.com  
 **Personal Interests:** Table tennis, ambient music, John Coltrane, powered by code, coffee and music
 
 ## Professional Summary
 
-I'm a passionate code enthusiast with over 15 years of experience turning coffee into high-performance web applications. I specialize in creating seamless user experiences and have had the privilege of working with major brands like Disney, Autodesk, General Motors, Frontier Communications, Carnival Cruise, Telmex, Mexico's Presidency, and Coca-Cola.
+I'm a Senior Software Engineer with over 15 years of experience building large-scale web applications, now working primarily on AI platform infrastructure. At Disney I'm helping migrate away from third-party chatbot vendors to a fully in-house conversational AI system that orchestrates multiple LLMs against Disney's own data, serving self-service and virtual assistance to millions of subscribers daily. Much of my focus is the infrastructure underneath: observability, architecture, and the services that connect to each other so every response can be traced, monitored, and made as reliable and useful as possible.
+
+I've had the privilege of working with major brands including Disney, Autodesk, General Motors, Frontier Communications, Carnival Cruise, Telmex, Mexico's Presidency, and Coca-Cola.
+
+**A note on how I describe myself:** I started as a front-end specialist and spent most of my career there, but that label no longer covers the work. Between LLM orchestration, observability infrastructure, cloud architecture, and backend services, I consider myself a software engineer rather than specifically a front-end or full-stack developer.
+
+## Current Role: Disney (Nov 2025 – Present)
+
+Senior Software Engineer, San Francisco Bay Area (via Kelly Mitchell).
+
+**AI platform and LLM infrastructure**
+
+- Driving Disney's migration from limited third-party chatbot vendors to a fully in-house self-service conversational AI platform, orchestrating multiple LLMs and integrating Disney data services to deliver more accurate, context-aware answers to millions of subscribers.
+- Designing and building the LLM observability infrastructure with Datadog and LiteLLM, instrumenting every AI call across the platform to capture token usage, latency, cost, and error metrics. The goal is that no response is a black box — every one can be traced and attributed.
+- Implementing automated alerting for model downtime, latency spikes, and usage anomalies, routing incidents to Microsoft Teams and PagerDuty for rapid detection and response.
+- Working across architecture and infrastructure-as-code with Terraform, designing the paths and services that connect to each other so the platform stays reliable, secure, and observable end to end.
+- Working with multiple AI providers (Anthropic and OpenAI APIs among them) and multi-model orchestration, so the platform isn't locked to a single vendor.
+
+**Product engineering**
+
+- Building and maintaining Baymax, Disney's customer service platform, where agents handle payments, subscriptions, cancellations, upgrades, and account management across multiple services including fraud detection, money transfers, and country-specific constraints.
+- Delivering AI-driven search and input capabilities that improve agent efficiency and accuracy when resolving complex customer issues in real time.
+- Contributing to Felix, an internal open-source platform that lets teams across Disney integrate MCP servers, connect repositories, and streamline common engineering workflows with AI-first tooling.
+- Running day-to-day development through Claude Code with MCP integrations for Datadog, Playwright, Jira, Figma, GitHub, and LaunchDarkly — building features, running tests, triaging issues, and managing deployments from one agentic interface.
+
+## Certifications
+
+**Certified Professional for Software Architecture — Foundation Level (CPSA-F)**  
+iSAQB (International Software Architecture Qualification Board), issued by Certible — April 2026.
+
+This is a formal credential in software architecture fundamentals: architecture design and decision-making, documenting and communicating architectures, quality requirements and how architecture serves them, and evaluating trade-offs. It backs up with a recognized standard the architectural work William had already been doing in practice.
+
+## Recent Experience
+
+**Disney — Senior Software Engineer** (via Kelly Mitchell), Nov 2025 – Present. See "Current Role" above.
+
+**SQOR.ai — Full-Stack Developer & Designer** (startup), May 2025 – Nov 2025. Built full-stack features and APIs with React, TypeScript, MUI, TanStack Query, Node.js, and MongoDB for an AI-powered analytics platform. Built the APIs powering the intelligence loop, storing and serving outputs from multiple LLMs as they analyzed client data in real time and generated dynamic charts and business recommendations. Delivered live-updating dashboard interfaces and contributed design direction with Next.js and Tailwind.
+
+**Craigraphics LLC — Full Stack Developer & Founder**, Aug 2024 – Dec 2025. For client ECUcomm, led a complete site rebuild with Next.js 15, TypeScript, Tailwind CSS, and Sanity CMS, improving performance, UI, UX, SEO, and accessibility. Integrated AWS SES for transactional email, deployed with CI/CD on Vercel, and handed over a self-managed CMS.
+
+**Autodesk — Full Stack Engineer** (via Globant), Feb 2020 – Jul 2024. Led front-end architecture during kickoff and early stages of Autodesk's Profile single-page app serving one million monthly users, built with React, GraphQL, and Node.js. Improved load times by 30% through code-splitting, lazy loading, and library optimization. First developer hired for the Profile team; took on tech lead responsibilities including foundational architecture decisions, system flow design, and micro-frontend hosting for multiple teams. Built a shared React component library with Lerna and Rollup, and connected front-end apps to AWS infrastructure using Lambda, serverless functions, S3, and CloudFront. Mentored junior developers.
+
+**Frontier Communications — Senior Web UI Developer** (via Globant), Jun 2016 – Feb 2020. Directed redesign and development of the company blog, a finalist for Best Blog Awards 2020 at the US Social Media Awards. Delivered emergency alert pages on tight timelines during severe weather events.
+
+**Carnival Cruise — Web UI Developer** (via Globant), Jun 2015 – May 2016. Led front-end development and a small team building an AngularJS single-page app for cruise ship kiosks covering movie ticketing, reviews, trailers, showtimes, and ticket redemption across varied kiosk hardware.
+
+**5M2 — Senior Front-End Developer**, Feb 2014 – Aug 2015. Led front-end development of GOB.mx, Mexico's national government portal, focusing on accessibility and performance for hundreds of millions of users. Designed and implemented a standardized design system and style guide framework adopted by federal agencies nationwide.
+
+**Telmex — Senior Front-End Developer** (via Global Hitss), May 2013 – Jan 2014. Contributed to the redesign and reconstruction of Telmex.com, one of the most visited websites in Latin America, using Liferay, vanilla JS, jQuery, and SASS.
+
+**Interalia — Senior Front-End Developer**, Jan 2010 – May 2013. Built microsites, web campaigns, and interactive experiences for General Motors brands (Chevrolet, Buick, Cadillac) and Coca-Cola Latin America.
 
 ## Frequently Asked Questions (FAQ)
 
 ### 1. What projects has William worked on?
 
-William has worked on large-scale web apps for companies like Disney, Autodesk, General Motors, and Frontier. In most cases, he was the lead front-end developer or a senior engineer on the team. He's rebuilt legacy systems, improved performance, and helped define architecture decisions. At Autodesk, for example, he led the front-end direction for a Profile Management project that scaled to thousands of users.
+Most recently at Disney, where he's building the in-house conversational AI platform that's replacing third-party chatbot vendors for self-service across millions of subscribers, along with Baymax (the customer service platform agents use for payments, subscriptions, and account management) and Felix (an internal open-source platform for MCP server integration). Before that he worked on large-scale web apps for Autodesk, General Motors, and Frontier, usually as lead front-end developer or senior engineer. At Autodesk he led the front-end direction for the Profile project, which scaled to a million monthly users. He's rebuilt legacy systems, improved performance, and helped define architecture decisions throughout.
 
 ### 2. How does William build modern web apps?
 
 He focuses on performance, maintainability, and user experience. That means smart code splitting, minimizing bundle size, optimizing rendering, and ensuring accessibility and responsiveness. William uses tools like Webpack, Vite, or BIT for optimization and relies on metrics and monitoring to back up decisions. He also makes sure the design isn't just visually appealing — it works well under real conditions.
 
-### 3. What sets William apart as a full-stack developer?
+### 3. What sets William apart as an engineer?
 
-William has a hybrid background — a degree in graphic design and over 15 years of experience writing production-grade code. He thinks in terms of both UX and technical quality. He also takes ownership of projects: he doesn't just code what he's told — he questions assumptions, suggests better flows, and pushes for better outcomes. He cares about performance and product impact, not just shipping tasks.
+An unusually wide span. He has a degree in graphic design and over 15 years writing production code, so he thinks in terms of both UX and technical quality — and he's now doing platform and infrastructure work: LLM orchestration, observability, architecture, and infrastructure-as-code. That combination is rare; most people sit on one side of it. He also takes ownership: he doesn't just code what he's told, he questions assumptions, suggests better flows, and pushes for better outcomes. In April 2026 he earned the iSAQB CPSA-Foundation certification in software architecture, formalizing the architectural work he was already doing.
 
 ### 4. What's an example of a challenge William solved?
 
-At Globant, William had to modernize a legacy app with no documentation and poor performance. He rewrote critical parts using a clean component structure in React, implemented lazy loading, and reduced the initial load time by over 50%. That opened the door for a better developer experience and faster feature delivery.
+At Disney, the self-service AI platform had to be observable before it could be trusted — with multiple LLMs and providers in play, a bad or slow answer is hard to diagnose after the fact. He built the observability layer with Datadog and LiteLLM so that every AI call is instrumented for token usage, latency, cost, and errors, then wired automated alerting for model downtime, latency spikes, and usage anomalies into Microsoft Teams and PagerDuty. That turned an opaque system into one where problems surface quickly and every response can be traced.
+
+Earlier, at Globant, he modernized a legacy app with no documentation and poor performance — rewriting critical parts with a clean React component structure and lazy loading, cutting initial load time by over 50%.
 
 ### 5. What industries has William worked in?
 
-William has worked across tech, telecom, automotive, cruise lines, and government. For example, he contributed to an accessibility overhaul for General Motors' design system, worked on performance improvements for Carnival Cruise's public site, and helped launch internal tools for the Presidency of Mexico. Across the board, he's helped teams ship faster, with better UX and more maintainable codebases.
+Entertainment and streaming, tech, telecom, automotive, cruise lines, and government. He's currently at Disney working on AI platform infrastructure for subscriber self-service. He contributed to an accessibility overhaul for General Motors' design system, worked on performance improvements for Carnival Cruise, and helped launch GOB.mx for the Presidency of Mexico. Across the board, he's helped teams ship faster, with better UX and more maintainable codebases.
 
 ### 6. How does William stay up to date with tech?
 
-William constantly experiments with new technologies — often by building side projects that incorporate things like TanStack Query, MDX, or the latest features in Next.js. He keeps up with technical blogs, studies architecture patterns from courses and interviews, and tends to question trends rather than blindly adopt them. His focus is on understanding the "why" before committing to any new stack or tool.
+William constantly experiments with new technologies — often by building side projects that incorporate things like TanStack Query, MDX, or the latest features in Next.js. He also pursues formal study when it's worth it, earning the iSAQB CPSA-Foundation architecture certification in 2026. He keeps up with technical blogs, studies architecture patterns, and tends to question trends rather than blindly adopt them. His focus is on understanding the "why" before committing to any new stack or tool.
 
 ### 7. What tech does William use and prefer?
 
-William specializes in React, TypeScript, and modern front-end frameworks like Next.js and Angular. He's also comfortable working full-stack with Node.js and has experience integrating GraphQL and REST APIs. On the styling side, he has strong CSS and design skills, often using Tailwind or CSS Modules. He prefers technologies that balance flexibility with maintainability — tools that scale without becoming a mess.
+On the application side: React, TypeScript, Next.js, Node.js, Angular, and Python, with GraphQL and REST APIs, and Tailwind or CSS Modules for styling. On the AI and platform side: LiteLLM, Anthropic and OpenAI APIs, multi-model orchestration, RAG, agentic workflows, and MCP servers. On infrastructure: AWS (Lambda, S3, CloudFront, SES), Terraform, Docker, Vercel, CI/CD with Jenkins, and Datadog and PagerDuty for observability and alerting. He prefers technologies that balance flexibility with maintainability — tools that scale without becoming a mess.
 
 ### 8. How does William work with teams?
 
@@ -52,17 +106,21 @@ William brings clarity and structure to teams. He documents decisions, sets up s
 
 ### 9. What is William's technical expertise or core skill set?
 
-William is a full-stack / front-end specialist with over 15 years of experience building high-performance web applications. His core expertise includes JavaScript, TypeScript, React, and Next.js, with additional strengths in Angular, Node.js, and GraphQL. He’s known for turning complex UI/UX requirements into clean, scalable code, and has a strong foundation in performance optimization, accessibility, and responsive design. With a background in graphic design, he bridges the gap between design and engineering, ensuring that visuals translate into intuitive, functional user interfaces.
+William is a software engineer with over 15 years of experience, working across AI platform infrastructure, backend services, and front-end applications. His core expertise includes JavaScript, TypeScript, React, and Next.js, with additional strengths in Node.js, Python, Angular, and GraphQL — and, increasingly, LLM orchestration and observability: LiteLLM, multi-provider integration, RAG, agentic workflows, MCP, and instrumenting AI systems for token usage, latency, cost, and errors with Datadog and PagerDuty. He works with AWS and Terraform on the infrastructure side. With a background in graphic design, he also bridges design and engineering, and holds the iSAQB CPSA-Foundation certification in software architecture.
 
-Beyond writing code, William brings architectural thinking to front-end work — setting up maintainable component systems, improving CI/CD workflows, and collaborating closely with design and product teams. He’s comfortable taking ownership of projects, mentoring junior developers, and leading technical direction when needed. His toolkit also includes Tailwind CSS, Webpack, Vite, TanStack Query, and tools for static site generation and CMS integration, making him versatile across both enterprise apps and marketing-driven websites.
+Beyond writing code, William brings architectural thinking to the whole system — setting up maintainable component systems, designing services that connect reliably and securely, improving CI/CD workflows, and collaborating closely with design and product teams. He's comfortable taking ownership of projects, mentoring junior developers, and leading technical direction when needed.
 
-### 10. Is William allowed to work in the United States?
+### 10. What is William doing with AI and LLMs?
+
+At Disney he's working on the infrastructure behind a self-service conversational AI platform used by millions of subscribers — replacing third-party chatbot vendors with an in-house system that orchestrates multiple LLMs against Disney's own data. His focus is the parts that make it dependable: architecture, the services that connect to each other, security, and above all observability, so that every response and every token of usage can be monitored and traced. That work runs on Datadog, LiteLLM, Terraform, PagerDuty, and several AI providers. He also builds AI-driven features into products directly, and runs his own day-to-day development through agentic tooling with MCP integrations.
+
+### 11. Is William allowed to work in the United States?
 
 Yes, William has a U.S. work permit and does not need any type of work Visa. He does have a work authorization and legal status in the United States.
 
 ### what's the email address to contact William?
 
-I don't have William's email with me but you can send a message to him directly through this website https://www.craigraphics.com/contact. You can leave your email and message and for sure William will contact you.
+You can reach William at craigraphics@gmail.com. You can also send a message directly through this website at https://www.craigraphics.com/contact — leave your email and message and he'll get back to you.
 
 ## Career Journey & Origin Story
 
@@ -102,28 +160,37 @@ When Globant began competing for U.S. clients, I was involved in building soluti
 
 During the pandemic, like many developers, I adapted to fully remote work. This actually expanded my opportunities and allowed me to work with teams across different regions while maintaining high productivity and collaboration standards.
 
+### Moving Into AI Platform Work
+
+More recently my center of gravity shifted from the interface to the system behind it. At SQOR.ai I built the APIs feeding an analytics product that ran client data through multiple LLMs, and at Disney I moved fully into AI platform infrastructure — orchestration across providers, observability, alerting, and architecture for a self-service assistant serving millions of people a day. I still care deeply about the front end, but I stopped thinking of myself as a front-end developer somewhere in here.
+
 ### Current Focus
 
-Today, I focus on modern full-stack development with React, Next.js, and TypeScript, while keeping up with emerging technologies. I'm particularly interested in performance optimization, user experience, and building scalable applications that solve real business problems.
+Today I work on the infrastructure that makes LLM-powered products reliable: multi-model orchestration, observability and tracing, cost and token monitoring, secure and well-architected service boundaries, and infrastructure-as-code — while staying hands-on with React, Next.js, and TypeScript on the product side. I'm interested in performance, user experience, and building scalable systems that solve real business problems.
 
 ## Notable Characteristics
 
 - Strong focus on user experience and performance
-- Experience with high-traffic applications (Autodesk, Telmex)
+- Experience with high-traffic and high-scale systems (Disney, Autodesk, Telmex)
+- AI platform and LLM observability experience at consumer scale
+- Certified in software architecture (iSAQB CPSA-Foundation, 2026)
 - Leadership experience with small to medium teams
 - Government sector experience (Mexico's digital transformation)
 - International client experience (US, Mexico, Latin America)
 - Bilingual professional (English/Spanish)
 - Award-winning project recognition (US Social Media Awards)
 
-## Current Technologies Stack (2024)
+## Current Technologies Stack (2026)
 
-- **Frontend:** Next.js 15, React 19, TypeScript
-- **Styling:** Tailwind CSS, ChadCN UI
-- **Backend:** Node.js, Express
+- **Frontend:** Next.js (App Router), React, TypeScript, Angular
+- **Styling:** Tailwind CSS, MUI, shadcn/ui
+- **Backend:** Node.js, Express, Python
+- **AI & LLM:** LiteLLM, Anthropic and OpenAI APIs, multi-model orchestration, RAG, agentic workflows, MCP servers
+- **Observability:** Datadog (APM, monitors, LLM observability), PagerDuty, Microsoft Teams alerting
 - **Database:** MongoDB, PostgreSQL
-- **Deployment:** Vercel, AWS
-- **Tools:** Figma, Git, Docker, CI/CD
+- **Infrastructure:** AWS (Lambda, S3, CloudFront, SES), Terraform, Docker, Vercel
+- **Testing:** Jest, Cypress, Playwright, Storybook
+- **Tools:** Claude Code, Figma, Git, Jenkins, CI/CD, LaunchDarkly
 
 ## Professional Philosophy & Approach
 
@@ -148,9 +215,16 @@ Today, I focus on modern full-stack development with React, Next.js, and TypeScr
 - Comprehensive skill set spanning performance optimization, accessibility improvements, and cross-team project delivery
 - Brings mix of experience, problem-solving, and collaborative mindset to every challenge
 
+### Systems & Reliability Philosophy
+
+- If it isn't observable, it isn't finished — instrument the system so failures surface on their own
+- Design service boundaries for security and traceability, not just for the happy path
+- Prefer infrastructure as code so environments are reproducible rather than hand-tuned
+- Measure cost and usage as first-class metrics, especially with LLMs where both scale quickly
+
 ### Full-Stack Philosophy
 
-- Frontend-focused with strong backend understanding
+- Works across the stack, from interface down to infrastructure
 - Believes in staying hands-on and learning new technologies
 - Enjoys solving problems that go beyond a single layer of the stack
 - Combines strategic thinking with technical implementation


### PR DESCRIPTION
The chatbot's knowledge base still described William as a front-end/full-stack developer and stopped at the Autodesk era. This brings it current with the Disney AI platform work and the shift in what the role actually is.

Content only — no application code. Independent of the chat-route PR, so the two can merge in either order.

## `william-craig-knowledge.md`

- **Disney role added** (Nov 2025 – Present): the migration from third-party chatbot vendors to an in-house conversational AI platform orchestrating multiple LLMs over Disney data for millions of subscribers, and the observability and alerting infrastructure behind it — Datadog, LiteLLM, Terraform, PagerDuty, Microsoft Teams. Plus Baymax (customer service platform) and Felix (internal MCP integration platform).
- **Positioning reframed.** The file described a front-end/full-stack developer throughout. It now leads with *software engineer*, with the reasoning stated explicitly so the bot can answer "is he a front-end dev?" directly instead of implying the old label.
- **iSAQB CPSA-Foundation certification** (April 2026, issued by Certible) — new section, plus the header and three FAQ answers.
- **Structured experience section added.** The file previously had only a narrative career story with no dates, roles, or employers, so the bot couldn't answer "where has he worked and when?" All nine roles are now listed.
- **New FAQ** on the AI/LLM work; refreshed the answers whose scope had gone stale (projects, what sets him apart, example challenge, industries, tech preferences, core skills).
- Stack section moved from 2024 to 2026.
- Contact answer now includes `craigraphics@gmail.com` alongside the contact form.

## Site copy

- `messages/en.json` and `messages/es.json` — the intro paragraph still read "high-performance web applications" for Autodesk/Frontier/Coca-Cola with no mention of Disney. Rewritten in both locales, keeping the existing voice (coffee, no superpowers, smooth like water).
- `components/TechStack.tsx` — added Terraform, Datadog, and LLM Orchestration badges with tooltip data, and credited Disney on React, Next.js, TypeScript, Python, and AI.

The site's work-history entries in `messages/*.json` already had correct Disney and SQOR.ai records; only the intro paragraph lagged.

## Sources

`William_Craig_Resume_2026.docx` plus William's own description of the current work. Terraform is the one item that came from the latter only — it is not on the resume.

## Verification

- `tsc --noEmit` clean.
- Production build (`next build`) succeeds, all 19 static pages generated across both locales.
- `en.json` and `es.json` both parse and have identical key structure (no locale drift).
- Every TechStack badge has a matching tooltip entry.

## Notes for review

- **This is public-facing copy about a real person** — worth reading the wording rather than just the diff.
- Adding the email means the chatbot will hand it out on request, and anything in the knowledge base can be extracted verbatim by anyone who asks. The phone number from the resume was deliberately left out.
- Two claims carried over from the resume as worded there: "15+ years" (arguably 16+ given the Jan 2010 start) and "millions of subscribers".
- **Pre-existing bug left alone:** the `A11y` badge in TechStack has no tooltip data, while an unused `Accessibility` entry sits in the map. Fixing it means renaming one or the other — the data key (badge keeps reading "A11y") or the badge (visible UI text changes). Left for a decision rather than picked silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
